### PR TITLE
Implement login page

### DIFF
--- a/mobile_frontend/lib/core/di/cubits_init.dart
+++ b/mobile_frontend/lib/core/di/cubits_init.dart
@@ -3,11 +3,16 @@ import 'package:Finance/features/main/cubits/main/main_cubit.dart';
 import 'package:Finance/features/shared/domain/repository/shared_repository.dart';
 import 'package:Finance/features/shared/presentation/cubits/navigate/navigate_cubit.dart';
 import '../../features/auth/presentation/cubit/splash/splash_cubit.dart';
+import '../../features/auth/presentation/cubit/login/login_cubit.dart';
+import '../../features/auth/domain/usecase/login_user.dart';
 import 'get_it.dart';
 
 Future<void> cubitsInit() async {
   getItInstance.registerFactory<SplashCubit>(
     () => SplashCubit(getItInstance<SharedRepository>()),
+  );
+  getItInstance.registerFactory<LoginCubit>(
+    () => LoginCubit(getItInstance<LoginUser>()),
   );
   getItInstance.registerFactory<NavigateCubit>(
     () => NavigateCubit(getItInstance<NavigationService>()),

--- a/mobile_frontend/lib/core/di/repositories_init.dart
+++ b/mobile_frontend/lib/core/di/repositories_init.dart
@@ -1,5 +1,9 @@
 import '../../features/shared/data/repository/shared_repository_impl.dart';
 import '../../features/shared/domain/repository/shared_repository.dart';
+import '../../features/auth/data/repository/login_repository_impl.dart';
+import '../../features/auth/domain/data_source/login_data_source.dart';
+import '../../features/auth/domain/repository/login_repository.dart';
+import '../../features/auth/domain/usecase/login_user.dart';
 import '../navigation/app_pages.dart';
 import '../navigation/navigation_service.dart';
 import '../network/api_client.dart';
@@ -25,5 +29,18 @@ Future<void> repositoriesInit() async {
 
   getItInstance.registerFactory<SharedRepository>(
     () => SharedRepositoryImpl(getItInstance<LocalDataSource>()),
+  );
+
+  getItInstance.registerLazySingleton<LoginDataSource>(
+    () => LoginDataSourceImpl(getItInstance<ApiClient>()),
+  );
+  getItInstance.registerLazySingleton<LoginRepository>(
+    () => LoginRepositoryImpl(
+      getItInstance<LocalDataSource>(),
+      getItInstance<LoginDataSource>(),
+    ),
+  );
+  getItInstance.registerLazySingleton<LoginUser>(
+    () => LoginUser(getItInstance<LoginRepository>()),
   );
 }

--- a/mobile_frontend/lib/core/navigation/app_pages.dart
+++ b/mobile_frontend/lib/core/navigation/app_pages.dart
@@ -3,7 +3,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../features/auth/presentation/pages/splash.dart';
+import '../../features/auth/presentation/pages/login.dart';
 import '../../features/main/cubits/main/main_cubit.dart';
+import '../../features/auth/presentation/cubit/login/login_cubit.dart';
 import '../constants/app_routes.dart';
 import '../di/get_it.dart';
 
@@ -17,6 +19,14 @@ class AppPages {
           GoRoute(
             path: AppRoutes.splashScreen,
             builder: (context, state) => const SplashScreen(),
+          ),
+
+          GoRoute(
+            path: AppRoutes.login,
+            builder: (context, state) => BlocProvider(
+              create: (context) => getItInstance<LoginCubit>(),
+              child: const LoginPage(),
+            ),
           ),
 
           GoRoute(

--- a/mobile_frontend/lib/features/auth/data/repository/login_repository_impl.dart
+++ b/mobile_frontend/lib/features/auth/data/repository/login_repository_impl.dart
@@ -19,7 +19,12 @@ class LoginRepositoryImpl with LoginRepository {
     try {
       final response = await _loginDataSource.loginUser(request: request);
       if (response.data != null) {
-        return Right(response.data ?? LoginUserResponse());
+        final data = response.data ?? LoginUserResponse();
+        final token = data.data?.accessToken ?? '';
+        if (token.isNotEmpty) {
+          await _localDataSource.setUserToken(token);
+        }
+        return Right(data);
       } else {
         return Left(
           Failure(

--- a/mobile_frontend/lib/features/auth/presentation/pages/login.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/login.dart
@@ -4,13 +4,87 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
+import '../../../shared/presentation/cubits/navigate/navigate_cubit.dart';
+import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
+import '../../../shared/presentation/widgets/textfields/w_masked_textfield.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/app_sizes.dart';
+import '../../../../core/constants/locale_keys.dart';
+import '../../../../core/helpers/enums_helpers.dart';
 import '../cubit/login/login_cubit.dart';
 
-class LoginPage extends StatelessWidget {
+class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
 
   @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _phoneController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _phoneController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _login() {
+    context.read<LoginCubit>().login(
+          phone: _phoneController.text,
+          password: _passwordController.text,
+        );
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Container();
+    return BlocConsumer<LoginCubit, LoginState>(
+      listener: (context, state) {
+        if (state.status == RequestStatus.loaded) {
+          context.read<NavigateCubit>().goToMainPage();
+        }
+      },
+      builder: (context, state) {
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(LocaleKeys.enter.tr()),
+          ),
+          body: Padding(
+            padding: const EdgeInsets.all(AppSizes.paddingM16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                WMaskedTextField(
+                  controller: _phoneController,
+                  hintText: LocaleKeys.userName.tr(),
+                ),
+                SizedBox(height: AppSizes.spaceM16.h),
+                WMaskedTextField(
+                  controller: _passwordController,
+                  hintText: LocaleKeys.password.tr(),
+                  isPassword: true,
+                ),
+                if (state.status == RequestStatus.error)
+                  Padding(
+                    padding: EdgeInsets.only(top: AppSizes.spaceS12.h),
+                    child: Text(
+                      state.errorMessage ?? '',
+                      style: const TextStyle(color: AppColors.error),
+                    ),
+                  ),
+                SizedBox(height: AppSizes.spaceM16.h),
+                WButton(
+                  onTap: _login,
+                  isLoading: state.status == RequestStatus.loading,
+                  text: LocaleKeys.enter.tr(),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
   }
 }

--- a/mobile_frontend/lib/features/auth/presentation/pages/splash.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/splash.dart
@@ -4,6 +4,7 @@ import 'package:Finance/features/shared/presentation/cubits/navigate/navigate_cu
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../../core/di/get_it.dart';
+import '../../../shared/domain/repository/shared_repository.dart';
 import '../cubit/splash/splash_cubit.dart';
 
 class SplashScreen extends StatelessWidget {
@@ -16,7 +17,12 @@ class SplashScreen extends StatelessWidget {
       child: BlocConsumer<SplashCubit, SplashState>(
         listener: (context, state) {
           if (state.status == RequestStatus.loaded) {
-            context.read<NavigateCubit>().goToMainPage();
+            final token = getItInstance<SharedRepository>().getToken();
+            if (token.isNotEmpty) {
+              context.read<NavigateCubit>().goToMainPage();
+            } else {
+              context.read<NavigateCubit>().goToLoginPage();
+            }
           }
         },
         builder: (context, state) {

--- a/mobile_frontend/lib/features/shared/presentation/cubits/navigate/navigate_cubit.dart
+++ b/mobile_frontend/lib/features/shared/presentation/cubits/navigate/navigate_cubit.dart
@@ -16,4 +16,8 @@ class NavigateCubit extends Cubit<NavigateState> {
   void goToMainPage() {
     _navigationService.navigateTo(AppRoutes.home);
   }
+
+  void goToLoginPage() {
+    _navigationService.navigateTo(AppRoutes.login);
+  }
 }


### PR DESCRIPTION
## Summary
- add navigation to login page
- register login cubit and repositories in DI
- store token after successful login
- implement login page UI
- navigate to login or home from splash depending on token

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6857ec7147748327b3aab3cc8023343a