### PR TITLE
Fix password field multiline assertion

### DIFF
--- a/mobile_frontend/lib/features/shared/presentation/widgets/textfields/w_masked_textfield.dart
+++ b/mobile_frontend/lib/features/shared/presentation/widgets/textfields/w_masked_textfield.dart
@@ -81,7 +81,7 @@ class WMaskedTextField extends StatelessWidget {
       child: SizedBox(
         height: height.h,
         child: TextField(
-          maxLines: maxLines,
+          maxLines: isPassword ? 1 : maxLines,
           autofocus: autofocus,
           style: style ?? AppTextStyles.bodyRegular,
           controller: controller,


### PR DESCRIPTION
## Summary
- ensure password fields always use single line

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f07b0cd4832790c2a3a9bc2294b3