### PR TITLE
Add logout API to Flutter frontend

### DIFF
--- a/mobile_frontend/lib/core/constants/local_storage_keys.dart
+++ b/mobile_frontend/lib/core/constants/local_storage_keys.dart
@@ -2,6 +2,7 @@ class LocalStorageKeys {
   static const String box = "box";
   static const String token = "token";
   static const String tokenType = "tokenType";
+  static const String refreshToken = "refreshToken";
   static const String language = "language";
   static const String verified = "verified";
   static const String role = "role";

--- a/mobile_frontend/lib/core/network/api_client.dart
+++ b/mobile_frontend/lib/core/network/api_client.dart
@@ -7,6 +7,7 @@ import 'package:retrofit/retrofit.dart';
 import '../../features/auth/data/model/request/login_user_request.dart';
 import '../../features/auth/data/model/response/login_user_response.dart';
 import '../../features/profile/data/model/profile_response.dart';
+import '../../features/profile/data/model/logout_request.dart';
 import '../constants/app_api.dart';
 import '../constants/app_constants.dart';
 import '../helpers/logger_helpers.dart';
@@ -71,7 +72,7 @@ abstract class ApiClient {
   Future<ProfileResponse> getProfile();
 
   @POST(AppApi.logout)
-  Future<void> logout();
+  Future<void> logout(@Body() LogoutRequest request);
 
 
 }

--- a/mobile_frontend/lib/core/network/api_client.g.dart
+++ b/mobile_frontend/lib/core/network/api_client.g.dart
@@ -87,11 +87,11 @@ class _ApiClient implements ApiClient {
   }
 
   @override
-  Future<void> logout() async {
+  Future<void> logout(LogoutRequest request) async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
-    final _data = <String, dynamic>{};
+    final _data = request.toJson();
     final _options = _setStreamType<void>(Options(
       method: 'POST',
       headers: _headers,

--- a/mobile_frontend/lib/core/storage/local_data_source.dart
+++ b/mobile_frontend/lib/core/storage/local_data_source.dart
@@ -1,9 +1,13 @@
 mixin LocalDataSource {
   String getToken();
 
+  String getRefreshToken();
+
   String getTokenType();
 
   Future<void> setUserToken(String token);
+
+  Future<void> setRefreshToken(String token);
 
   Future<void> setTokenType(String tokenType);
 

--- a/mobile_frontend/lib/core/storage/local_data_source_impl.dart
+++ b/mobile_frontend/lib/core/storage/local_data_source_impl.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:hive/hive.dart';
 
 import '../constants/local_storage_keys.dart';
@@ -13,6 +11,12 @@ class LocalDataSourceImpl implements LocalDataSource {
   }
 
   @override
+  String getRefreshToken() {
+    final box = Hive.box(LocalStorageKeys.box);
+    return box.get(LocalStorageKeys.refreshToken, defaultValue: "");
+  }
+
+  @override
   String getTokenType() {
     final box = Hive.box(LocalStorageKeys.box);
     return box.get(LocalStorageKeys.tokenType, defaultValue: "Bearer");
@@ -22,6 +26,12 @@ class LocalDataSourceImpl implements LocalDataSource {
   Future<void> setUserToken(String token) async {
     final box = Hive.box(LocalStorageKeys.box);
     return box.put(LocalStorageKeys.token, token);
+  }
+
+  @override
+  Future<void> setRefreshToken(String token) async {
+    final box = Hive.box(LocalStorageKeys.box);
+    await box.put(LocalStorageKeys.refreshToken, token);
   }
 
   @override

--- a/mobile_frontend/lib/features/auth/data/repository/login_repository_impl.dart
+++ b/mobile_frontend/lib/features/auth/data/repository/login_repository_impl.dart
@@ -29,6 +29,7 @@ class LoginRepositoryImpl with LoginRepository {
         final token = data.accessToken;
         if (token.isNotEmpty) {
           await _localDataSource.setUserToken(token);
+          await _localDataSource.setRefreshToken(data.refreshToken);
           await _localDataSource.setTokenType(data.tokenType);
         }
         return Right(data);

--- a/mobile_frontend/lib/features/profile/data/model/logout_request.dart
+++ b/mobile_frontend/lib/features/profile/data/model/logout_request.dart
@@ -1,0 +1,7 @@
+class LogoutRequest {
+  final String refresh;
+
+  const LogoutRequest({required this.refresh});
+
+  Map<String, dynamic> toJson() => {'refresh': refresh};
+}

--- a/mobile_frontend/lib/features/profile/data/repository/profile_repository_impl.dart
+++ b/mobile_frontend/lib/features/profile/data/repository/profile_repository_impl.dart
@@ -3,6 +3,7 @@ import 'package:dartz/dartz.dart';
 import '../../../../core/network/api_client.dart';
 import '../../../../core/network/failure.dart';
 import '../../../../core/storage/local_data_source.dart';
+import '../model/logout_request.dart';
 import '../../domain/repository/profile_repository.dart';
 import '../model/profile_response.dart';
 
@@ -24,9 +25,11 @@ class ProfileRepositoryImpl with ProfileRepository {
   @override
   Future<Either<Failure, void>> logout() async {
     try {
-      await _client.logout();
+      final refresh = _localDataSource.getRefreshToken();
+      await _client.logout(LogoutRequest(refresh: refresh));
     } catch (_) {}
     await _localDataSource.setUserToken('');
+    await _localDataSource.setRefreshToken('');
     return const Right(null);
   }
 }


### PR DESCRIPTION
## Summary
- store refresh tokens and expose them via LocalDataSource
- create LogoutRequest model for logout API
- send refresh token when calling logout
- persist refresh token on login

## Testing
- `dart format --set-exit-if-changed mobile_frontend/lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685811d4af208327b3a3829a15a1f571