### PR TITLE
Add register and forgot password pages

### DIFF
--- a/mobile_frontend/lib/core/constants/app_routes.dart
+++ b/mobile_frontend/lib/core/constants/app_routes.dart
@@ -1,6 +1,8 @@
 class AppRoutes {
   static const String home = '/home';
   static const String login = '/login';
+  static const String register = '/register';
+  static const String forgotPassword = '/forgot-password';
   static const String splashScreen = '/';
   static const String settings = '/settings';
   static const String profile = '/profile';

--- a/mobile_frontend/lib/core/navigation/app_pages.dart
+++ b/mobile_frontend/lib/core/navigation/app_pages.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 
 import '../../features/auth/presentation/pages/splash.dart';
 import '../../features/auth/presentation/pages/login.dart';
+import '../../features/auth/presentation/pages/register.dart';
+import '../../features/auth/presentation/pages/forgot_password.dart';
 import '../../features/main/cubits/main/main_cubit.dart';
 import '../../features/auth/presentation/cubit/login/login_cubit.dart';
 import '../../features/profile/presentation/pages/profile_page.dart';
@@ -29,6 +31,16 @@ class AppPages {
               create: (context) => getItInstance<LoginCubit>(),
               child: const LoginPage(),
             ),
+          ),
+
+          GoRoute(
+            path: AppRoutes.register,
+            builder: (context, state) => const RegisterPage(),
+          ),
+
+          GoRoute(
+            path: AppRoutes.forgotPassword,
+            builder: (context, state) => const ForgotPasswordPage(),
           ),
 
           GoRoute(

--- a/mobile_frontend/lib/features/auth/presentation/pages/forgot_password.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/forgot_password.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../../../../core/constants/app_sizes.dart';
+import '../../../../core/constants/locale_keys.dart';
+import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
+import '../../../shared/presentation/widgets/textfields/w_masked_textfield.dart';
+
+class ForgotPasswordPage extends StatefulWidget {
+  const ForgotPasswordPage({super.key});
+
+  @override
+  State<ForgotPasswordPage> createState() => _ForgotPasswordPageState();
+}
+
+class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
+  final _usernameController = TextEditingController();
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    super.dispose();
+  }
+
+  void _send() {
+    // Forgot password logic will be implemented later
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Forgot password')),
+      body: Padding(
+        padding: const EdgeInsets.all(AppSizes.paddingM16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            WMaskedTextField(
+              controller: _usernameController,
+              hintText: LocaleKeys.userName.tr(),
+            ),
+            SizedBox(height: AppSizes.spaceM16.h),
+            WButton(
+              onTap: _send,
+              text: 'Send',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_frontend/lib/features/auth/presentation/pages/login.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/login.dart
@@ -80,6 +80,23 @@ class _LoginPageState extends State<LoginPage> {
                   isLoading: state.status == RequestStatus.loading,
                   text: LocaleKeys.enter.tr(),
                 ),
+                SizedBox(height: AppSizes.spaceM16.h),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    TextButton(
+                      onPressed: () =>
+                          context.read<NavigateCubit>().goToRegisterPage(),
+                      child: const Text('Register'),
+                    ),
+                    TextButton(
+                      onPressed: () => context
+                          .read<NavigateCubit>()
+                          .goToForgotPasswordPage(),
+                      child: const Text('Forgot password?'),
+                    ),
+                  ],
+                ),
               ],
             ),
           ),

--- a/mobile_frontend/lib/features/auth/presentation/pages/register.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/register.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+import '../../../../core/constants/app_sizes.dart';
+import '../../../../core/constants/locale_keys.dart';
+import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
+import '../../../shared/presentation/widgets/textfields/w_masked_textfield.dart';
+
+class RegisterPage extends StatefulWidget {
+  const RegisterPage({super.key});
+
+  @override
+  State<RegisterPage> createState() => _RegisterPageState();
+}
+
+class _RegisterPageState extends State<RegisterPage> {
+  final _usernameController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  void _register() {
+    // Registration logic will be implemented later
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Register')),
+      body: Padding(
+        padding: const EdgeInsets.all(AppSizes.paddingM16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            WMaskedTextField(
+              controller: _usernameController,
+              hintText: LocaleKeys.userName.tr(),
+            ),
+            SizedBox(height: AppSizes.spaceM16.h),
+            WMaskedTextField(
+              controller: _passwordController,
+              hintText: LocaleKeys.password.tr(),
+              isPassword: true,
+            ),
+            SizedBox(height: AppSizes.spaceM16.h),
+            WMaskedTextField(
+              controller: _confirmPasswordController,
+              hintText: 'Confirm password',
+              isPassword: true,
+            ),
+            SizedBox(height: AppSizes.spaceM16.h),
+            WButton(
+              onTap: _register,
+              text: 'Register',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_frontend/lib/features/shared/presentation/cubits/navigate/navigate_cubit.dart
+++ b/mobile_frontend/lib/features/shared/presentation/cubits/navigate/navigate_cubit.dart
@@ -20,4 +20,12 @@ class NavigateCubit extends Cubit<NavigateState> {
   void goToLoginPage() {
     _navigationService.navigateTo(AppRoutes.login);
   }
+
+  void goToRegisterPage() {
+    _navigationService.navigateTo(AppRoutes.register);
+  }
+
+  void goToForgotPasswordPage() {
+    _navigationService.navigateTo(AppRoutes.forgotPassword);
+  }
 }


### PR DESCRIPTION
## Summary
- create registration and forgot password screens
- expose routes for the new pages
- add navigation helpers
- link to new pages from login

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581793614883279d3b4e6fca0054fe