### PR TITLE
Refactor text fields into shared widget

### DIFF
--- a/mobile_frontend/lib/features/shared/widgets/app_text_field.dart
+++ b/mobile_frontend/lib/features/shared/widgets/app_text_field.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import '../../../core/constants/app_colors.dart';
+
+class AppTextField extends StatefulWidget {
+  final String label;
+  final TextEditingController controller;
+  final bool isPassword;
+  final bool isEmail;
+  final bool isNumber;
+  final bool enabled;
+
+  const AppTextField({
+    super.key,
+    required this.label,
+    required this.controller,
+    this.isPassword = false,
+    this.isEmail = false,
+    this.isNumber = false,
+    this.enabled = true,
+  });
+
+  @override
+  State<AppTextField> createState() => _AppTextFieldState();
+}
+
+class _AppTextFieldState extends State<AppTextField> {
+  late bool _obscure;
+
+  @override
+  void initState() {
+    super.initState();
+    _obscure = widget.isPassword;
+  }
+
+  TextInputType _keyboardType() {
+    if (widget.isEmail) return TextInputType.emailAddress;
+    if (widget.isNumber) return TextInputType.number;
+    return TextInputType.text;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppColors.background,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: TextField(
+        controller: widget.controller,
+        enabled: widget.enabled,
+        keyboardType: _keyboardType(),
+        obscureText: widget.isPassword ? _obscure : false,
+        style: const TextStyle(color: AppColors.textPrimary),
+        decoration: InputDecoration(
+          label: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
+            decoration: BoxDecoration(
+              color: AppColors.background,
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Text(
+              widget.label,
+              style: const TextStyle(
+                color: AppColors.textSecondary,
+                fontWeight: FontWeight.w600,
+                fontSize: 16,
+              ),
+            ),
+          ),
+          floatingLabelBehavior: FloatingLabelBehavior.auto,
+          filled: true,
+          fillColor: AppColors.background,
+          contentPadding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: BorderSide.none,
+          ),
+          suffixIcon: widget.isPassword
+              ? Material(
+                  color: Colors.transparent,
+                  borderRadius: BorderRadius.circular(12),
+                  child: InkWell(
+                    borderRadius: const BorderRadius.only(
+                      topRight: Radius.circular(12),
+                      bottomRight: Radius.circular(12),
+                    ),
+                    splashColor: AppColors.primary,
+                    highlightColor: AppColors.primary,
+                    onTap: () {
+                      setState(() {
+                        _obscure = !_obscure;
+                      });
+                    },
+                    child: Padding(
+                      padding: const EdgeInsets.all(10.0),
+                      child: Image.asset(
+                        _obscure
+                            ? 'Assets/Icons/Icon - pwd_hide.png'
+                            : 'Assets/Icons/Icon - pwd_show.png',
+                        width: 20,
+                        height: 20,
+                      ),
+                    ),
+                  ),
+                )
+              : null,
+        ),
+      ),
+    );
+  }
+}

--- a/screens_/login_screen.dart
+++ b/screens_/login_screen.dart
@@ -3,6 +3,7 @@ import 'package:frontend/theme.dart';
 import '../services/auth_service.dart';
 import 'register_screen.dart';
 import 'reset_password_screen.dart';
+import '../mobile_frontend/lib/features/shared/widgets/app_text_field.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -20,7 +21,6 @@ class _LoginScreenState extends State<LoginScreen> {
   final TextEditingController _passController = TextEditingController();
 
   bool _isLoading = false;
-  bool _obscurePassword = true;
   String? _errorMessage;
 
   @override
@@ -76,9 +76,18 @@ class _LoginScreenState extends State<LoginScreen> {
               ),
             ),
             const SizedBox(height: _spacingHeight),
-            _buildTextField('Username', _loginController),
+            AppTextField(
+              label: 'Username',
+              controller: _loginController,
+              enabled: !_isLoading,
+            ),
             const SizedBox(height: _spacingHeight),
-            _buildTextField('Password', _passController, isPassword: true),
+            AppTextField(
+              label: 'Password',
+              controller: _passController,
+              isPassword: true,
+              enabled: !_isLoading,
+            ),
             if (_errorMessage != null)
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 8),
@@ -169,74 +178,5 @@ class _LoginScreenState extends State<LoginScreen> {
     );
   }
 
-  Widget _buildTextField(String label, TextEditingController controller,
-      {bool isPassword = false}) {
-    return Container(
-      decoration: BoxDecoration(
-        color: AppColors.background,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: TextField(
-        controller: controller,
-        enabled: !_isLoading,
-        obscureText: isPassword ? _obscurePassword : false,
-        style: const TextStyle(color: AppColors.textPrimary),
-        decoration: InputDecoration(
-          label: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
-            decoration: BoxDecoration(
-              color: AppColors.background,
-              borderRadius: BorderRadius.circular(6),
-            ),
-            child: Text(
-              label,
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontWeight: FontWeight.w600,
-                fontSize: 16,
-              ),
-            ),
-          ),
-          floatingLabelBehavior: FloatingLabelBehavior.auto,
-          filled: true,
-          fillColor: AppColors.background,
-          contentPadding:
-              const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(12),
-            borderSide: BorderSide.none,
-          ),
-          suffixIcon: isPassword
-              ? Material(
-                  color: Colors.transparent,
-                  borderRadius: BorderRadius.circular(12),
-                  child: InkWell(
-                    borderRadius: const BorderRadius.only(
-                        topRight: Radius.circular(12),
-                        bottomRight: Radius.circular(12)),
-                    splashColor: AppColors.primary,
-                    highlightColor: AppColors.primary,
-                    onTap: () {
-                      setState(() {
-                        _obscurePassword = !_obscurePassword;
-                      });
-                    },
-                    child: Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: Image.asset(
-                        _obscurePassword
-                            ? 'Assets/Icons/Icon - pwd_hide.png'
-                            : 'Assets/Icons/Icon - pwd_show.png',
-                        width: 20,
-                        height: 20,
-                      ),
-                    ),
-                  ),
-                )
-              : null,
-        ),
-      ),
-    );
-  }
 }
 

--- a/screens_/register_screen.dart
+++ b/screens_/register_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:frontend/theme.dart';
 import '../services/auth_service.dart';
 import 'login_screen.dart';
+import '../mobile_frontend/lib/features/shared/widgets/app_text_field.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({super.key});
@@ -21,8 +22,6 @@ class _RegisterScreenState extends State<RegisterScreen> {
   final TextEditingController _verifyPassController = TextEditingController();
 
   bool _isLoading = false;
-  bool _obscurePassword = true;
-  bool _obscureVerifyPassword = true;
   String? _errorMessage;
 
   @override
@@ -93,14 +92,31 @@ class _RegisterScreenState extends State<RegisterScreen> {
               style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: AppColors.surface),
             ),
             const SizedBox(height: _spacingHeight),
-            _buildTextField('Username', _loginController),
+            AppTextField(
+              label: 'Username',
+              controller: _loginController,
+              enabled: !_isLoading,
+            ),
             const SizedBox(height: _spacingHeight),
-            _buildTextField('E-mail', _emailController),
+            AppTextField(
+              label: 'E-mail',
+              controller: _emailController,
+              enabled: !_isLoading,
+            ),
             const SizedBox(height: _spacingHeight),
-            _buildTextField('Password', _passController, isPassword: true),
+            AppTextField(
+              label: 'Password',
+              controller: _passController,
+              isPassword: true,
+              enabled: !_isLoading,
+            ),
             const SizedBox(height: _spacingHeight),
-            _buildTextField('Verify password', _verifyPassController,
-                isPassword: true, isVerify: true),
+            AppTextField(
+              label: 'Verify password',
+              controller: _verifyPassController,
+              isPassword: true,
+              enabled: !_isLoading,
+            ),
             if (_errorMessage != null)
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 8),
@@ -152,79 +168,5 @@ class _RegisterScreenState extends State<RegisterScreen> {
     );
   }
 
-  Widget _buildTextField(String label, TextEditingController controller,
-      {bool isPassword = false, bool isVerify = false}) {
-    return Container(
-      decoration: BoxDecoration(
-        color: AppColors.background,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: TextField(
-        controller: controller,
-        enabled: !_isLoading,
-        obscureText:
-            isPassword ? (isVerify ? _obscureVerifyPassword : _obscurePassword) : false,
-        style: const TextStyle(color: AppColors.textPrimary),
-        decoration: InputDecoration(
-          label: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
-            decoration: BoxDecoration(
-              color: AppColors.background,
-              borderRadius: BorderRadius.circular(6),
-            ),
-            child: Text(
-              label,
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontWeight: FontWeight.w600,
-                fontSize: 16,
-              ),
-            ),
-          ),
-          floatingLabelBehavior: FloatingLabelBehavior.auto,
-          filled: true,
-          fillColor: AppColors.background,
-          contentPadding:
-              const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(12),
-            borderSide: BorderSide.none,
-          ),
-          suffixIcon: isPassword
-              ? Material(
-                  color: Colors.transparent,
-                  borderRadius: BorderRadius.circular(12),
-                  child: InkWell(
-                    borderRadius: const BorderRadius.only(
-                        topRight: Radius.circular(12),
-                        bottomRight: Radius.circular(12)),
-                    splashColor: AppColors.primary,
-                    highlightColor: AppColors.primary,
-                    onTap: () {
-                      setState(() {
-                        if (isVerify) {
-                          _obscureVerifyPassword = !_obscureVerifyPassword;
-                        } else {
-                          _obscurePassword = !_obscurePassword;
-                        }
-                      });
-                    },
-                    child: Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: Image.asset(
-                        (isVerify ? _obscureVerifyPassword : _obscurePassword)
-                            ? 'Assets/Icons/Icon - pwd_hide.png'
-                            : 'Assets/Icons/Icon - pwd_show.png',
-                        width: 20,
-                        height: 20,
-                      ),
-                    ),
-                  ),
-                )
-              : null,
-        ),
-      ),
-    );
-  }
 }
 

--- a/screens_/reset_password_screen.dart
+++ b/screens_/reset_password_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:frontend/theme.dart';
 import '../services/auth_service.dart';
 import 'login_screen.dart';
+import '../mobile_frontend/lib/features/shared/widgets/app_text_field.dart';
 
 class ResetPasswordScreen extends StatefulWidget {
   const ResetPasswordScreen({super.key});
@@ -22,8 +23,6 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
 
   bool _isLoading = false;
   bool _isSent = false;
-  bool _obscurePassword = true;
-  bool _obscureVerifyPassword = true;
   String? _infoMessage;
 
   @override
@@ -96,14 +95,33 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
               style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: AppColors.surface),
             ),
             const SizedBox(height: _spacingHeight),
-            _buildTextField('E-mail', _emailController, isEmail: true),
+            AppTextField(
+              label: 'E-mail',
+              controller: _emailController,
+              isEmail: true,
+              enabled: !_isLoading && !_isSent,
+            ),
             const SizedBox(height: _spacingHeight),
-            _buildTextField('TOTP code', _codeController, isNumber: true),
+            AppTextField(
+              label: 'TOTP code',
+              controller: _codeController,
+              isNumber: true,
+              enabled: !_isLoading && !_isSent,
+            ),
             const SizedBox(height: _spacingHeight),
-            _buildTextField('New password', _passController, isPassword: true),
+            AppTextField(
+              label: 'New password',
+              controller: _passController,
+              isPassword: true,
+              enabled: !_isLoading && !_isSent,
+            ),
             const SizedBox(height: _spacingHeight),
-            _buildTextField('Verify password', _verifyPassController,
-                isPassword: true, isVerify: true),
+            AppTextField(
+              label: 'Verify password',
+              controller: _verifyPassController,
+              isPassword: true,
+              enabled: !_isLoading && !_isSent,
+            ),
             const SizedBox(height: _spacingHeight),
             SizedBox(
               height: _buttonHeight,
@@ -166,90 +184,5 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
     );
   }
 
-  Widget _buildTextField(
-    String label,
-    TextEditingController controller, {
-    bool isPassword = false,
-    bool isVerify = false,
-    bool isNumber = false,
-    bool isEmail = false,
-  }) {
-    return Container(
-      decoration: BoxDecoration(
-        color: AppColors.background,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: TextField(
-        controller: controller,
-        enabled: !_isLoading && !_isSent,
-        keyboardType: isEmail
-            ? TextInputType.emailAddress
-            : isNumber
-                ? TextInputType.number
-                : TextInputType.text,
-        obscureText:
-            isPassword ? (isVerify ? _obscureVerifyPassword : _obscurePassword) : false,
-        style: const TextStyle(color: AppColors.textPrimary),
-        decoration: InputDecoration(
-          label: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 2),
-            decoration: BoxDecoration(
-              color: AppColors.background,
-              borderRadius: BorderRadius.circular(6),
-            ),
-            child: Text(
-              label,
-              style: const TextStyle(
-                color: AppColors.textSecondary,
-                fontWeight: FontWeight.w600,
-                fontSize: 16,
-              ),
-            ),
-          ),
-          floatingLabelBehavior: FloatingLabelBehavior.auto,
-          filled: true,
-          fillColor: AppColors.background,
-          contentPadding:
-              const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(12),
-            borderSide: BorderSide.none,
-          ),
-          suffixIcon: isPassword
-              ? Material(
-                  color: Colors.transparent,
-                  borderRadius: BorderRadius.circular(12),
-                  child: InkWell(
-                    borderRadius: const BorderRadius.only(
-                        topRight: Radius.circular(12),
-                        bottomRight: Radius.circular(12)),
-                    splashColor: AppColors.primary,
-                    highlightColor: AppColors.primary,
-                    onTap: () {
-                      setState(() {
-                        if (isVerify) {
-                          _obscureVerifyPassword = !_obscureVerifyPassword;
-                        } else {
-                          _obscurePassword = !_obscurePassword;
-                        }
-                      });
-                    },
-                    child: Padding(
-                      padding: const EdgeInsets.all(10.0),
-                      child: Image.asset(
-                        (isVerify ? _obscureVerifyPassword : _obscurePassword)
-                            ? 'Assets/Icons/Icon - pwd_hide.png'
-                            : 'Assets/Icons/Icon - pwd_show.png',
-                        width: 20,
-                        height: 20,
-                      ),
-                    ),
-                  ),
-                )
-              : null,
-        ),
-      ),
-    );
-  }
 }
 


### PR DESCRIPTION
## Summary
- add `AppTextField` widget under `features/shared/widgets`
- use the new widget in login, register and reset password screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686153ce90b88327ad281ee875aef876