### PR TITLE
Use encrypted Hive box

### DIFF
--- a/mobile_frontend/lib/core/constants/local_storage_keys.dart
+++ b/mobile_frontend/lib/core/constants/local_storage_keys.dart
@@ -10,4 +10,5 @@ class LocalStorageKeys {
   static const String userId = "userId";
   static const String phone = "phone";
   static const String email = "email";
+  static const String encryptionKey = "encKey";
 }

--- a/mobile_frontend/lib/core/di/repositories_init.dart
+++ b/mobile_frontend/lib/core/di/repositories_init.dart
@@ -4,6 +4,7 @@ import '../../features/auth/data/repository/login_repository_impl.dart';
 import '../../features/auth/domain/data_source/login_data_source.dart';
 import '../../features/auth/domain/repository/login_repository.dart';
 import '../../features/auth/domain/usecase/login_user.dart';
+import '../../features/auth/domain/usecase/refresh_token.dart';
 import '../../features/profile/data/repository/profile_repository_impl.dart';
 import '../../features/profile/domain/repository/profile_repository.dart';
 import '../../features/profile/domain/usecase/get_profile.dart';
@@ -51,6 +52,10 @@ Future<void> repositoriesInit() async {
 
   getItInstance.registerLazySingleton<LoginUser>(
     () => LoginUser(getItInstance<LoginRepository>()),
+  );
+
+  getItInstance.registerLazySingleton<RefreshToken>(
+    () => RefreshToken(getItInstance<LoginRepository>()),
   );
 
   getItInstance.registerLazySingleton<ProfileRepository>(

--- a/mobile_frontend/lib/core/network/api_client.dart
+++ b/mobile_frontend/lib/core/network/api_client.dart
@@ -8,6 +8,7 @@ import '../../features/auth/data/model/request/login_user_request.dart';
 import '../../features/auth/data/model/response/login_user_response.dart';
 import '../../features/profile/data/model/profile_response.dart';
 import '../../features/profile/data/model/logout_request.dart';
+import '../../features/auth/data/model/request/refresh_token_request.dart';
 import '../constants/app_api.dart';
 import '../constants/app_constants.dart';
 import '../helpers/logger_helpers.dart';
@@ -67,6 +68,11 @@ abstract class ApiClient {
 
   @POST(AppApi.login)
   Future<LoginUserResponse> loginUser(@Body() LoginUserRequest request);
+
+  @POST(AppApi.r_token)
+  Future<LoginUserResponse> refreshToken(
+      @Body() RefreshTokenRequest request,
+  );
 
   @GET(AppApi.me)
   Future<ProfileResponse> getProfile();

--- a/mobile_frontend/lib/core/network/api_client.g.dart
+++ b/mobile_frontend/lib/core/network/api_client.g.dart
@@ -55,6 +55,39 @@ class _ApiClient implements ApiClient {
   }
 
   @override
+  Future<LoginUserResponse> refreshToken(RefreshTokenRequest request) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = request.toJson();
+    final _options = _setStreamType<LoginUserResponse>(Options(
+      method: 'POST',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '/auth/refresh',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late LoginUserResponse _value;
+    try {
+      _value = LoginUserResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
   Future<ProfileResponse> getProfile() async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};

--- a/mobile_frontend/lib/core/storage/hive_service.dart
+++ b/mobile_frontend/lib/core/storage/hive_service.dart
@@ -1,13 +1,21 @@
+import 'dart:typed_data';
+
 import 'package:hive/hive.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../constants/local_storage_keys.dart';
+import 'secure_storage_service.dart';
 
 class HiveService {
   static Future<HiveService> init() async {
     final appDocumentDir = await getApplicationDocumentsDirectory();
     Hive.init(appDocumentDir.path);
-    await Hive.openBox(LocalStorageKeys.box);
+
+    final Uint8List encryptionKey = await SecureStorageService.getEncryptionKey();
+    await Hive.openBox(
+      LocalStorageKeys.box,
+      encryptionCipher: HiveAesCipher(encryptionKey),
+    );
     return HiveService();
   }
 }

--- a/mobile_frontend/lib/core/storage/secure_storage_service.dart
+++ b/mobile_frontend/lib/core/storage/secure_storage_service.dart
@@ -1,0 +1,23 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:hive/hive.dart';
+
+import '../constants/local_storage_keys.dart';
+
+class SecureStorageService {
+  static const FlutterSecureStorage _storage = FlutterSecureStorage();
+
+  static Future<Uint8List> getEncryptionKey() async {
+    String? encodedKey =
+        await _storage.read(key: LocalStorageKeys.encryptionKey);
+    if (encodedKey == null) {
+      final Uint8List key = Hive.generateSecureKey();
+      encodedKey = base64UrlEncode(key);
+      await _storage.write(key: LocalStorageKeys.encryptionKey, value: encodedKey);
+      return key;
+    }
+    return base64Url.decode(encodedKey);
+  }
+}

--- a/mobile_frontend/lib/features/auth/data/model/request/refresh_token_request.dart
+++ b/mobile_frontend/lib/features/auth/data/model/request/refresh_token_request.dart
@@ -1,0 +1,7 @@
+class RefreshTokenRequest {
+  final String refreshToken;
+
+  const RefreshTokenRequest({required this.refreshToken});
+
+  Map<String, dynamic> toJson() => {'refresh_token': refreshToken};
+}

--- a/mobile_frontend/lib/features/auth/data/repository/login_repository_impl.dart
+++ b/mobile_frontend/lib/features/auth/data/repository/login_repository_impl.dart
@@ -4,6 +4,7 @@ import '../../../../core/storage/local_data_source.dart';
 import '../../domain/data_source/login_data_source.dart';
 import '../../domain/repository/login_repository.dart';
 import '../model/request/login_user_request.dart';
+import '../model/request/refresh_token_request.dart';
 import '../model/response/login_user_response.dart';
 
 class LoginRepositoryImpl with LoginRepository {
@@ -37,6 +38,33 @@ class LoginRepositoryImpl with LoginRepository {
         return Left(
           Failure(
             errorMessage: response.getException()?.getErrorMessage() ?? "Error",
+          ),
+        );
+      }
+    } catch (e) {
+      return Left(Failure(errorMessage: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, LoginUserResponse>> refreshToken() async {
+    try {
+      final refresh = _localDataSource.getRefreshToken();
+      final response = await _loginDataSource.refreshToken(
+        request: RefreshTokenRequest(refreshToken: refresh),
+      );
+      if (response.data != null) {
+        final data = response.data!;
+        if (data.accessToken.isNotEmpty) {
+          await _localDataSource.setUserToken(data.accessToken);
+          await _localDataSource.setRefreshToken(data.refreshToken);
+          await _localDataSource.setTokenType(data.tokenType);
+        }
+        return Right(data);
+      } else {
+        return Left(
+          Failure(
+            errorMessage: response.getException()?.getErrorMessage() ?? 'Error',
           ),
         );
       }

--- a/mobile_frontend/lib/features/auth/domain/data_source/login_data_source.dart
+++ b/mobile_frontend/lib/features/auth/domain/data_source/login_data_source.dart
@@ -5,12 +5,17 @@ import '../../../../core/constants/app_api.dart';
 import '../../../../core/network/response_handler.dart';
 import '../../../../core/network/server_error.dart';
 import '../../data/model/request/login_user_request.dart';
+import '../../data/model/request/refresh_token_request.dart';
 import '../../data/model/response/login_user_response.dart';
 
 /// Contract for login data source.
 abstract class LoginDataSource {
   Future<ResponseHandler<LoginUserResponse>> loginUser({
     required LoginUserRequest request,
+  });
+
+  Future<ResponseHandler<LoginUserResponse>> refreshToken({
+    required RefreshTokenRequest request,
   });
 }
 
@@ -26,6 +31,32 @@ class LoginDataSourceImpl implements LoginDataSource {
         AppApi.login,
         data: request.toMap(),
         options: Options(contentType: Headers.formUrlEncodedContentType),
+      );
+      final data = LoginUserResponse.fromJson(
+        resp.data as Map<String, dynamic>,
+      );
+      return ResponseHandler()..data = data;
+    } catch (error, stacktrace) {
+      debugPrint('Exception occurred: $error stacktrace: $stacktrace');
+      final serverError = error is DioException
+          ? ServerError.withError(error: error)
+          : ServerError.withError(
+              error: DioException(
+                  requestOptions: RequestOptions(path: ''),
+                  error: error.toString()));
+      return ResponseHandler()..setException(serverError);
+    }
+  }
+
+  @override
+  Future<ResponseHandler<LoginUserResponse>> refreshToken({
+    required RefreshTokenRequest request,
+  }) async {
+    try {
+      final dio = Dio(BaseOptions(baseUrl: AppApi.baseUrlProd));
+      final resp = await dio.post(
+        AppApi.r_token,
+        data: request.toJson(),
       );
       final data = LoginUserResponse.fromJson(
         resp.data as Map<String, dynamic>,

--- a/mobile_frontend/lib/features/auth/domain/repository/login_repository.dart
+++ b/mobile_frontend/lib/features/auth/domain/repository/login_repository.dart
@@ -7,4 +7,6 @@ mixin LoginRepository {
   Future<Either<Failure,LoginUserResponse>> loginUser({
     required LoginUserRequest request,
   });
+
+  Future<Either<Failure, LoginUserResponse>> refreshToken();
 }

--- a/mobile_frontend/lib/features/auth/domain/usecase/refresh_token.dart
+++ b/mobile_frontend/lib/features/auth/domain/usecase/refresh_token.dart
@@ -1,0 +1,17 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/network/failure.dart';
+import '../../../../core/network/no_params.dart';
+import '../../../../core/network/use_case.dart';
+import '../../data/model/response/login_user_response.dart';
+import '../repository/login_repository.dart';
+
+class RefreshToken extends UseCase<LoginUserResponse, NoParams> {
+  final LoginRepository _repository;
+  RefreshToken(this._repository);
+
+  @override
+  Future<Either<Failure, LoginUserResponse>> call(NoParams params) {
+    return _repository.refreshToken();
+  }
+}

--- a/mobile_frontend/lib/features/profile/data/repository/profile_repository_impl.dart
+++ b/mobile_frontend/lib/features/profile/data/repository/profile_repository_impl.dart
@@ -30,6 +30,7 @@ class ProfileRepositoryImpl with ProfileRepository {
     } catch (_) {}
     await _localDataSource.setUserToken('');
     await _localDataSource.setRefreshToken('');
+    await _localDataSource.setTokenType('');
     return const Right(null);
   }
 }

--- a/mobile_frontend/pubspec.yaml
+++ b/mobile_frontend/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   shimmer: ^3.0.0
   flash: ^3.1.1
   hive: ^2.2.3
+  flutter_secure_storage: ^9.0.0
   cached_network_image: ^3.4.0
   flutter_native_splash: ^2.4.0
   path_provider: ^2.1.4


### PR DESCRIPTION
## Summary
- store encryption key using `flutter_secure_storage`
- open Hive box with AES cipher
- expose utility for encryption key
- update dependencies
- implement token rotation flow using refresh token API
- clear all token data on logout

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615977824483279af123a2021b57fe