### PR TITLE
Fix secure storage key type mismatch

### DIFF
--- a/mobile_frontend/lib/core/storage/secure_storage_service.dart
+++ b/mobile_frontend/lib/core/storage/secure_storage_service.dart
@@ -18,6 +18,6 @@ class SecureStorageService {
       await _storage.write(key: LocalStorageKeys.encryptionKey, value: encodedKey);
       return key;
     }
-    return base64Url.decode(encodedKey);
+    return Uint8List.fromList(base64Url.decode(encodedKey));
   }
 }


### PR DESCRIPTION
## Summary
- fix return type in `SecureStorageService.getEncryptionKey`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68639f845944832780734226908d5ae4