### PR TITLE
Improve auth page design

### DIFF
--- a/mobile_frontend/lib/features/auth/presentation/pages/forgot_password.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/forgot_password.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:easy_localization/easy_localization.dart';
 
+import '../../../../core/constants/app_images.dart';
 import '../../../../core/constants/app_sizes.dart';
 import '../../../../core/constants/locale_keys.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
@@ -31,21 +32,49 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Forgot password')),
-      body: Padding(
-        padding: const EdgeInsets.all(AppSizes.paddingM16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            WMaskedTextField(
-              controller: _usernameController,
-              hintText: LocaleKeys.userName.tr(),
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(AppSizes.paddingM16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Center(
+                  child: Image.asset(
+                    AppImages.logo,
+                    height: AppSizes.logoSmall60.h,
+                  ),
+                ),
+                SizedBox(height: AppSizes.spaceXL24.h),
+                Card(
+                  elevation: 4,
+                  shape: RoundedRectangleBorder(
+                    borderRadius:
+                        BorderRadius.circular(AppSizes.borderLarge20),
+                  ),
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.all(AppSizes.paddingM16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        WMaskedTextField(
+                          controller: _usernameController,
+                          hintText: LocaleKeys.userName.tr(),
+                        ),
+                        SizedBox(height: AppSizes.spaceM16.h),
+                        WButton(
+                          onTap: _send,
+                          text: 'Send',
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
             ),
-            SizedBox(height: AppSizes.spaceM16.h),
-            WButton(
-              onTap: _send,
-              text: 'Send',
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/mobile_frontend/lib/features/auth/presentation/pages/login.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/login.dart
@@ -8,6 +8,7 @@ import '../../../shared/presentation/cubits/navigate/navigate_cubit.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
 import '../../../shared/presentation/widgets/textfields/w_masked_textfield.dart';
 import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/app_images.dart';
 import '../../../../core/constants/app_sizes.dart';
 import '../../../../core/constants/locale_keys.dart';
 import '../../../../core/helpers/enums_helpers.dart';
@@ -51,53 +52,84 @@ class _LoginPageState extends State<LoginPage> {
           appBar: AppBar(
             title: Text(LocaleKeys.enter.tr()),
           ),
-          body: Padding(
-            padding: const EdgeInsets.all(AppSizes.paddingM16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                WMaskedTextField(
-                  controller: _phoneController,
-                  hintText: LocaleKeys.userName.tr(),
-                ),
-                SizedBox(height: AppSizes.spaceM16.h),
-                WMaskedTextField(
-                  controller: _passwordController,
-                  hintText: LocaleKeys.password.tr(),
-                  isPassword: true,
-                ),
-                if (state.status == RequestStatus.error)
-                  Padding(
-                    padding: EdgeInsets.only(top: AppSizes.spaceS12.h),
-                    child: Text(
-                      state.errorMessage ?? '',
-                      style: const TextStyle(color: AppColors.error),
-                    ),
-                  ),
-                SizedBox(height: AppSizes.spaceM16.h),
-                WButton(
-                  onTap: _login,
-                  isLoading: state.status == RequestStatus.loading,
-                  text: LocaleKeys.enter.tr(),
-                ),
-                SizedBox(height: AppSizes.spaceM16.h),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          body: SafeArea(
+            child: Center(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(AppSizes.paddingM16),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    TextButton(
-                      onPressed: () =>
-                          context.read<NavigateCubit>().goToRegisterPage(),
-                      child: const Text('Register'),
+                    Center(
+                      child: Image.asset(
+                        AppImages.logo,
+                        height: AppSizes.logoSmall60.h,
+                      ),
                     ),
-                    TextButton(
-                      onPressed: () => context
-                          .read<NavigateCubit>()
-                          .goToForgotPasswordPage(),
-                      child: const Text('Forgot password?'),
+                    SizedBox(height: AppSizes.spaceXL24.h),
+                    Card(
+                      elevation: 4,
+                      shape: RoundedRectangleBorder(
+                        borderRadius:
+                            BorderRadius.circular(AppSizes.borderLarge20),
+                      ),
+                      child: Padding(
+                        padding:
+                            const EdgeInsets.all(AppSizes.paddingM16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            WMaskedTextField(
+                              controller: _phoneController,
+                              hintText: LocaleKeys.userName.tr(),
+                            ),
+                            SizedBox(height: AppSizes.spaceM16.h),
+                            WMaskedTextField(
+                              controller: _passwordController,
+                              hintText: LocaleKeys.password.tr(),
+                              isPassword: true,
+                            ),
+                            if (state.status == RequestStatus.error)
+                              Padding(
+                                padding:
+                                    EdgeInsets.only(top: AppSizes.spaceS12.h),
+                                child: Text(
+                                  state.errorMessage ?? '',
+                                  style:
+                                      const TextStyle(color: AppColors.error),
+                                ),
+                              ),
+                            SizedBox(height: AppSizes.spaceM16.h),
+                            WButton(
+                              onTap: _login,
+                              isLoading:
+                                  state.status == RequestStatus.loading,
+                              text: LocaleKeys.enter.tr(),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    SizedBox(height: AppSizes.spaceM16.h),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        TextButton(
+                          onPressed: () =>
+                              context.read<NavigateCubit>().goToRegisterPage(),
+                          child: const Text('Register'),
+                        ),
+                        TextButton(
+                          onPressed: () => context
+                              .read<NavigateCubit>()
+                              .goToForgotPasswordPage(),
+                          child: const Text('Forgot password?'),
+                        ),
+                      ],
                     ),
                   ],
                 ),
-              ],
+              ),
             ),
           ),
         );

--- a/mobile_frontend/lib/features/auth/presentation/pages/register.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/register.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:easy_localization/easy_localization.dart';
 
+import '../../../../core/constants/app_images.dart';
 import '../../../../core/constants/app_sizes.dart';
 import '../../../../core/constants/locale_keys.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
@@ -35,33 +36,61 @@ class _RegisterPageState extends State<RegisterPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Register')),
-      body: Padding(
-        padding: const EdgeInsets.all(AppSizes.paddingM16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            WMaskedTextField(
-              controller: _usernameController,
-              hintText: LocaleKeys.userName.tr(),
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(AppSizes.paddingM16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Center(
+                  child: Image.asset(
+                    AppImages.logo,
+                    height: AppSizes.logoSmall60.h,
+                  ),
+                ),
+                SizedBox(height: AppSizes.spaceXL24.h),
+                Card(
+                  elevation: 4,
+                  shape: RoundedRectangleBorder(
+                    borderRadius:
+                        BorderRadius.circular(AppSizes.borderLarge20),
+                  ),
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.all(AppSizes.paddingM16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        WMaskedTextField(
+                          controller: _usernameController,
+                          hintText: LocaleKeys.userName.tr(),
+                        ),
+                        SizedBox(height: AppSizes.spaceM16.h),
+                        WMaskedTextField(
+                          controller: _passwordController,
+                          hintText: LocaleKeys.password.tr(),
+                          isPassword: true,
+                        ),
+                        SizedBox(height: AppSizes.spaceM16.h),
+                        WMaskedTextField(
+                          controller: _confirmPasswordController,
+                          hintText: 'Confirm password',
+                          isPassword: true,
+                        ),
+                        SizedBox(height: AppSizes.spaceM16.h),
+                        WButton(
+                          onTap: _register,
+                          text: 'Register',
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
             ),
-            SizedBox(height: AppSizes.spaceM16.h),
-            WMaskedTextField(
-              controller: _passwordController,
-              hintText: LocaleKeys.password.tr(),
-              isPassword: true,
-            ),
-            SizedBox(height: AppSizes.spaceM16.h),
-            WMaskedTextField(
-              controller: _confirmPasswordController,
-              hintText: 'Confirm password',
-              isPassword: true,
-            ),
-            SizedBox(height: AppSizes.spaceM16.h),
-            WButton(
-              onTap: _register,
-              text: 'Register',
-            ),
-          ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- redesign login, register, and forgot password pages
  - center pages in a scrollable card
  - add the app logo above each form
  - wrap forms in cards with rounded corners

## Testing
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a96fc5b08327a3e337274dd6eecd