### PR TITLE
Fix BuildContext.read errors

### DIFF
--- a/mobile_frontend/lib/features/auth/presentation/pages/forgot_password.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/forgot_password.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/constants/app_images.dart';
 import '../../../../core/constants/app_sizes.dart';

--- a/mobile_frontend/lib/features/auth/presentation/pages/register.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/register.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/constants/app_images.dart';
 import '../../../../core/constants/app_sizes.dart';


### PR DESCRIPTION
## Summary
- add missing flutter_bloc import for register page
- add missing flutter_bloc import for forgot password page

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863b465ad4c8327804565e438fd25bc