### PR TITLE
Fix missing flutter_bloc imports

### DIFF
--- a/mobile_frontend/lib/features/auth/presentation/pages/forgot_password.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/forgot_password.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/constants/app_images.dart';
 import '../../../../core/constants/app_sizes.dart';

--- a/mobile_frontend/lib/features/auth/presentation/pages/register.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/register.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/constants/app_images.dart';
 import '../../../../core/constants/app_sizes.dart';


### PR DESCRIPTION
## Summary
- enable BuildContext.read calls by importing flutter_bloc

## Testing
- `flutter analyze` *(fails: Finance requires SDK version ^3.7.2)*

------
https://chatgpt.com/codex/tasks/task_e_6871e09af3dc832789364ad284214e0b