### PR TITLE
Adjust nav bar labels and animation

### DIFF
--- a/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
+++ b/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
@@ -33,8 +33,8 @@ class _MainPageState extends State<MainPage> {
   _animateToPage(int index) {
     pageController.animateToPage(
       index,
-      duration: TimeDelays.short,
-      curve: Curves.easeInOut,
+      duration: TimeDelays.medium,
+      curve: Curves.easeInOutBack,
     );
   }
 
@@ -82,20 +82,21 @@ class _MainPageState extends State<MainPage> {
                 child: BottomNavigationBar(
                   backgroundColor: AppColors.textSecondary,
                   elevation: 4,
-                  items: <BottomNavigationBarItem>[
+                  items: const <BottomNavigationBarItem>[
                     BottomNavigationBarItem(
-                      icon: const Icon(Icons.home),
-                      label: LocaleKeys.home.tr(),
+                      icon: Icon(Icons.home),
+                      label: '',
                     ),
                     BottomNavigationBarItem(
-                      icon: const Icon(Icons.person),
-                      label: LocaleKeys.profile.tr(),
+                      icon: Icon(Icons.person),
+                      label: '',
                     ),
                   ],
                   currentIndex: state.currentIndex,
                   selectedItemColor: AppColors.primary,
                   unselectedItemColor: Colors.grey,
-                  showUnselectedLabels: true,
+                  showSelectedLabels: false,
+                  showUnselectedLabels: false,
                   onTap: setPageIndex,
                   type: BottomNavigationBarType.fixed,
                   selectedFontSize: 12,


### PR DESCRIPTION
## Summary
- remove text labels on the bottom navigation bar and center icons
- slow page change animation and use easeInOutBack curve

## Testing
- `apt-get update`
- `apt-get install -y bsdmainutils`

------
https://chatgpt.com/codex/tasks/task_e_68728c3ad46c8327bb9dbd404383a010