### PR TITLE
Add reusable navbar widget

### DIFF
--- a/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
+++ b/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
@@ -11,6 +11,7 @@ import '../../../../core/di/get_it.dart';
 
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/constants/app_sizes.dart';
+import '../../../shared/presentation/widgets/navbar/w_navbar.dart';
 
 class MainPage extends StatefulWidget {
   final int initialPage;
@@ -70,51 +71,25 @@ class _MainPageState extends State<MainPage> {
               ],
             ),
           ),
-          bottomNavigationBar: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: AppSizes.paddingS, vertical: AppSizes.paddingS),
-            child: ClipRRect(
-              borderRadius: const BorderRadius.vertical(bottom: Radius.circular(AppSizes.borderPageBottom), top: Radius.circular(AppSizes.borderMedium)),
-              child: Theme(
-                data: Theme.of(context).copyWith(
-                  splashColor: AppColors.primary.withOpacity(0.2),
-                  highlightColor: AppColors.primary.withOpacity(0.1),
+          bottomNavigationBar: WNavbar(
+            currentIndex: state.currentIndex,
+            onTap: setPageIndex,
+            items: const [
+              BottomNavigationBarItem(
+                icon: Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Icon(Icons.home),
                 ),
-                child: Padding(
-                  padding: const EdgeInsets.only(bottom: 12),
-                  child: Container(
-                    height: 72,
-                    child: BottomNavigationBar(
-                      backgroundColor: AppColors.textSecondary,
-                      items: const <BottomNavigationBarItem>[
-                        BottomNavigationBarItem(
-                          icon: Align(
-                            alignment: Alignment.bottomCenter,
-                            child: Icon(Icons.home)
-                          ),
-                          label: ''
-                        ),
-                        BottomNavigationBarItem(
-                          icon: Align(
-                            alignment: Alignment.bottomCenter,
-                            child: Icon(Icons.person)
-                          ),
-                          label: ''
-                        ),
-                      ],
-                      currentIndex: state.currentIndex,
-                      selectedItemColor: AppColors.primary,
-                      unselectedItemColor: AppColors.def,
-                      showSelectedLabels: false,
-                      showUnselectedLabels: false,
-                      onTap: setPageIndex,
-                      type: BottomNavigationBarType.fixed,
-                      iconSize: AppSizes.navbarIcon,
-                      enableFeedback: false,
-                    ),
-                  ),
-                ),
+                label: '',
               ),
-            ),
+              BottomNavigationBarItem(
+                icon: Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Icon(Icons.person),
+                ),
+                label: '',
+              ),
+            ],
           ),
         );
       },

--- a/mobile_frontend/lib/features/shared/presentation/widgets/navbar/w_navbar.dart
+++ b/mobile_frontend/lib/features/shared/presentation/widgets/navbar/w_navbar.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../../core/constants/app_colors.dart';
+import '../../../../../../core/constants/app_sizes.dart';
+
+/// A reusable bottom navigation bar styled according to the
+/// design used on [MainPage]. It accepts a list of navigation
+/// items and notifies about index changes via [onTap].
+class WNavbar extends StatelessWidget {
+  final int currentIndex;
+  final ValueChanged<int> onTap;
+  final List<BottomNavigationBarItem> items;
+
+  const WNavbar({
+    super.key,
+    required this.currentIndex,
+    required this.onTap,
+    required this.items,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSizes.paddingS,
+        vertical: AppSizes.paddingS,
+      ),
+      child: ClipRRect(
+        borderRadius: const BorderRadius.vertical(
+          bottom: Radius.circular(AppSizes.borderPageBottom),
+          top: Radius.circular(AppSizes.borderMedium),
+        ),
+        child: Theme(
+          data: Theme.of(context).copyWith(
+            splashColor: AppColors.primary.withOpacity(0.2),
+            highlightColor: AppColors.primary.withOpacity(0.1),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: SizedBox(
+              height: 72,
+              child: BottomNavigationBar(
+                backgroundColor: AppColors.textSecondary,
+                items: items,
+                currentIndex: currentIndex,
+                selectedItemColor: AppColors.primary,
+                unselectedItemColor: AppColors.def,
+                showSelectedLabels: false,
+                showUnselectedLabels: false,
+                onTap: onTap,
+                type: BottomNavigationBarType.fixed,
+                iconSize: AppSizes.navbarIcon,
+                enableFeedback: false,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create a reusable bottom navigation bar widget
- use this widget in `MainPage`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68729dbd24488327aa992be45f1744db