### PR TITLE
Fix navigation bar parameter type

### DIFF
--- a/mobile_frontend/lib/features/shared/presentation/widgets/navbar/w_navbar.dart
+++ b/mobile_frontend/lib/features/shared/presentation/widgets/navbar/w_navbar.dart
@@ -9,7 +9,8 @@ import '../../../../../../core/constants/app_sizes.dart';
 class WNavbar extends StatelessWidget {
   final int currentIndex;
   final ValueChanged<int> onTap;
-  final List<NavigationBar> destinations;
+  /// List of navigation destinations displayed inside the [NavigationBar].
+  final List<NavigationDestination> destinations;
 
   const WNavbar({
     super.key,


### PR DESCRIPTION
## Summary
- fix WNavbar `destinations` parameter to accept a list of `NavigationDestination`

## Testing
- `apt-get update` *(fails to run Flutter tests: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6872d4cb070c8327b1272410aabb849d