### PR TITLE
Implement CircularIconButton and app bars

### DIFF
--- a/mobile_frontend/lib/features/shared/presentation/widgets/app_buttons/w_circular_icon_button.dart
+++ b/mobile_frontend/lib/features/shared/presentation/widgets/app_buttons/w_circular_icon_button.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+
+class CircularIconButton extends StatelessWidget {
+  final dynamic icon;
+  final VoidCallback onTap;
+  final Color backgroundColor;
+  final Color iconColor;
+  final double size;
+  final bool showNotificationDot;
+
+  const CircularIconButton({
+    Key? key,
+    required this.icon,
+    required this.onTap,
+    this.backgroundColor = AppColors.secondary,
+    this.iconColor = Colors.black,
+    this.size = 40,
+    this.showNotificationDot = false,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    Widget iconWidget;
+    if (icon is IconData) {
+      iconWidget = Icon(icon as IconData, color: iconColor);
+    } else if (icon is Widget) {
+      iconWidget = icon as Widget;
+    } else {
+      throw ArgumentError('icon must be IconData or Widget');
+    }
+
+    return InkWell(
+      onTap: onTap,
+      customBorder: const CircleBorder(),
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Container(
+            width: size,
+            height: size,
+            decoration: BoxDecoration(
+              color: backgroundColor,
+              shape: BoxShape.circle,
+            ),
+            alignment: Alignment.center,
+            child: iconWidget,
+          ),
+          if (showNotificationDot)
+            Positioned(
+              top: 4,
+              right: 4,
+              child: Container(
+                width: size * 0.25,
+                height: size * 0.25,
+                decoration: const BoxDecoration(
+                  color: Colors.red,
+                  shape: BoxShape.circle,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile_frontend/lib/features/shared/presentation/widgets/appbar/w_inner_appbar.dart
+++ b/mobile_frontend/lib/features/shared/presentation/widgets/appbar/w_inner_appbar.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../../../core/constants/app_sizes.dart';
+import '../../../../../core/themes/app_text_styles.dart';
+import '../app_buttons/w_circular_icon_button.dart';
+
+class SubpageAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final VoidCallback onBackTap;
+  final VoidCallback? onNotificationTap;
+  final bool showNotificationDot;
+  final Gradient? gradient;
+  final Color? backgroundColor;
+
+  const SubpageAppBar({
+    Key? key,
+    required this.title,
+    required this.onBackTap,
+    this.onNotificationTap,
+    this.showNotificationDot = false,
+    this.gradient,
+    this.backgroundColor,
+  }) : super(key: key);
+
+  @override
+  Size get preferredSize => const Size.fromHeight(AppSizes.appBarHeight56);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: preferredSize.height,
+      decoration: BoxDecoration(
+        gradient: gradient ?? const LinearGradient(
+          colors: [AppColors.primary, AppColors.secondary],
+        ),
+        color: backgroundColor,
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.paddingL),
+      child: SafeArea(
+        bottom: false,
+        child: Row(
+          children: [
+            CircularIconButton(
+              icon: Icons.arrow_back,
+              onTap: onBackTap,
+              backgroundColor: AppColors.surface,
+              iconColor: AppColors.textPrimary,
+            ),
+            const SizedBox(width: AppSizes.spaceM16),
+            Expanded(
+              child: Center(
+                child: Text(
+                  title,
+                  style: AppTextStyles.bodyMedium,
+                ),
+              ),
+            ),
+            const SizedBox(width: AppSizes.spaceM16),
+            CircularIconButton(
+              icon: Icons.notifications,
+              onTap: onNotificationTap ?? () {},
+              backgroundColor: AppColors.surface,
+              iconColor: AppColors.textPrimary,
+              showNotificationDot: showNotificationDot,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_frontend/lib/features/shared/presentation/widgets/appbar/w_main_appbar.dart
+++ b/mobile_frontend/lib/features/shared/presentation/widgets/appbar/w_main_appbar.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+import '../../../../../core/constants/app_colors.dart';
+import '../../../../../core/constants/app_sizes.dart';
+import '../../../../../core/themes/app_text_styles.dart';
+import '../app_buttons/w_circular_icon_button.dart';
+
+class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
+  final String subtitle;
+  final ImageProvider profileImage;
+  final VoidCallback? onProfileTap;
+  final VoidCallback? onNotificationTap;
+  final bool showNotificationDot;
+  final Gradient? gradient;
+  final Color? backgroundColor;
+
+  const MainAppBar({
+    Key? key,
+    required this.title,
+    required this.subtitle,
+    required this.profileImage,
+    this.onProfileTap,
+    this.onNotificationTap,
+    this.showNotificationDot = false,
+    this.gradient,
+    this.backgroundColor,
+  }) : super(key: key);
+
+  @override
+  Size get preferredSize => const Size.fromHeight(AppSizes.appBarHeight56);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: preferredSize.height,
+      decoration: BoxDecoration(
+        gradient: gradient ?? const LinearGradient(
+          colors: [AppColors.primary, AppColors.secondary],
+        ),
+        color: backgroundColor,
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: AppSizes.paddingL),
+      child: SafeArea(
+        bottom: false,
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            GestureDetector(
+              onTap: onProfileTap,
+              child: CircleAvatar(
+                radius: 20,
+                backgroundImage: profileImage,
+              ),
+            ),
+            const SizedBox(width: AppSizes.spaceM16),
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    title,
+                    style: AppTextStyles.bodyMedium,
+                  ),
+                  Text(
+                    subtitle,
+                    style: AppTextStyles.labelRegular,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: AppSizes.spaceM16),
+            CircularIconButton(
+              icon: Icons.notifications,
+              onTap: onNotificationTap ?? () {},
+              backgroundColor: AppColors.surface,
+              iconColor: AppColors.textPrimary,
+              showNotificationDot: showNotificationDot,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `CircularIconButton` widget
- implement `MainAppBar` for navigation tabs
- implement `SubpageAppBar` for inner pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687392a21ff88327a98a3232a273adc5