### PR TITLE
Integrate custom app bars and fix tab sync

### DIFF
--- a/mobile_frontend/lib/features/auth/presentation/pages/forgot_password.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/forgot_password.dart
@@ -10,6 +10,7 @@ import '../../../shared/presentation/cubits/navigate/navigate_cubit.dart';
 import '../../../shared/presentation/widgets/textfields/w_masked_textfield.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_text_button.dart';
+import '../../../shared/presentation/widgets/appbar/w_inner_appbar.dart';
 
 class ForgotPasswordPage extends StatefulWidget {
   const ForgotPasswordPage({super.key});
@@ -35,9 +36,9 @@ class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.background,
-      appBar: AppBar(
-        elevation: 0,
-        backgroundColor: AppColors.background,
+      appBar: SubpageAppBar(
+        title: LocaleKeys.resetPassword.tr(),
+        onBackTap: () => Navigator.of(context).pop(),
       ),
       body: SafeArea(
         child: Center(

--- a/mobile_frontend/lib/features/auth/presentation/pages/login.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/login.dart
@@ -1,6 +1,5 @@
 import 'package:Finance/core/themes/app_text_styles.dart';
 import 'package:easy_localization/easy_localization.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -9,8 +8,8 @@ import '../../../shared/presentation/cubits/navigate/navigate_cubit.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_text_button.dart';
 import '../../../shared/presentation/widgets/textfields/w_masked_textfield.dart';
+import '../../../shared/presentation/widgets/appbar/w_inner_appbar.dart';
 import '../../../../core/constants/app_colors.dart';
-import '../../../../core/constants/app_images.dart';
 import '../../../../core/constants/app_sizes.dart';
 import '../../../../core/constants/locale_keys.dart';
 import '../../../../core/helpers/enums_helpers.dart';
@@ -52,9 +51,9 @@ class _LoginPageState extends State<LoginPage> {
       builder: (context, state) {
         return Scaffold(
           backgroundColor: AppColors.background,
-          appBar: AppBar(
-            elevation: 0,
-            backgroundColor: AppColors.background,
+          appBar: SubpageAppBar(
+            title: LocaleKeys.enter.tr(),
+            onBackTap: () => Navigator.of(context).pop(),
           ),
           body: SafeArea(
             child: Center(

--- a/mobile_frontend/lib/features/auth/presentation/pages/register.dart
+++ b/mobile_frontend/lib/features/auth/presentation/pages/register.dart
@@ -11,6 +11,7 @@ import '../../../shared/presentation/cubits/navigate/navigate_cubit.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_text_button.dart';
 import '../../../shared/presentation/widgets/textfields/w_masked_textfield.dart';
+import '../../../shared/presentation/widgets/appbar/w_inner_appbar.dart';
 
 class RegisterPage extends StatefulWidget {
   const RegisterPage({super.key});
@@ -54,9 +55,9 @@ class _RegisterPageState extends State<RegisterPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.background,
-      appBar: AppBar(
-        elevation: 0,
-        backgroundColor: AppColors.background,
+      appBar: SubpageAppBar(
+        title: LocaleKeys.signUp.tr(),
+        onBackTap: () => Navigator.of(context).pop(),
       ),
       body: SafeArea(
         child: Center(

--- a/mobile_frontend/lib/features/home/presentation/pages/home_page.dart
+++ b/mobile_frontend/lib/features/home/presentation/pages/home_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
-import '../../../../core/constants/app_colors.dart';
+import '../../../shared/presentation/widgets/appbar/w_main_appbar.dart';
+import '../../../../core/constants/app_images.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
@@ -8,10 +9,12 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: AppColors.background,
-        elevation: 0,
-        title: const Text('Home'),
+      appBar: MainAppBar(
+        title: 'Home',
+        subtitle: 'Welcome back',
+        profileImage: const AssetImage(AppImages.logo),
+        onProfileTap: () {},
+        onNotificationTap: () {},
       ),
       body: const Center(
         child: Text('Home Page'),

--- a/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
+++ b/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
@@ -31,6 +31,9 @@ class _MainPageState extends State<MainPage> {
   void initState() {
     super.initState();
     pageController = PageController(initialPage: widget.initialPage);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _updateState(widget.initialPage);
+    });
   }
 
   _animateToPage(int index) {
@@ -63,6 +66,7 @@ class _MainPageState extends State<MainPage> {
             },
             child: PageView(
               controller: pageController,
+              onPageChanged: _updateState,
               children: [
                 const HomePage(),
                 Container(),

--- a/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
+++ b/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
@@ -3,8 +3,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/themes/app_text_styles.dart';
-import '../../../shared/presentation/cubits/navigate/navigate_cubit.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
+import '../../../shared/presentation/widgets/appbar/w_main_appbar.dart';
+import '../../../../core/constants/app_images.dart';
 import '../cubit/profile_cubit.dart';
 import '../cubit/profile_state.dart';
 
@@ -25,9 +26,12 @@ class _ProfilePageState extends State<ProfilePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        backgroundColor: AppColors.background,
-        elevation: 0,
+      appBar: MainAppBar(
+        title: 'Profile',
+        subtitle: 'Your account',
+        profileImage: const AssetImage(AppImages.logo),
+        onProfileTap: () {},
+        onNotificationTap: () {},
       ),
       body: BlocBuilder<ProfileCubit, ProfileState>(
         builder: (context, state) {

--- a/mobile_frontend/lib/features/settings/presentation/pages/settings_page.dart
+++ b/mobile_frontend/lib/features/settings/presentation/pages/settings_page.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+import '../../../shared/presentation/widgets/appbar/w_inner_appbar.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: SubpageAppBar(
+        title: 'Settings',
+        onBackTap: () => Navigator.of(context).pop(),
+      ),
+      body: const Center(
+        child: Text('Settings page'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- use `MainAppBar` on HomePage and ProfilePage
- use `SubpageAppBar` on login/registration/forgot password screens
- create example `SettingsPage` that uses `SubpageAppBar`
- update `MainPage` to sync `PageView` index with BottomNavigationBar

## Testing
- `flutter analyze` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687395d7f9288327b3f1fa86d561ccf7