### PR TITLE
Implement main app bar with cached user info

### DIFF
--- a/mobile_frontend/lib/core/constants/local_storage_keys.dart
+++ b/mobile_frontend/lib/core/constants/local_storage_keys.dart
@@ -10,5 +10,6 @@ class LocalStorageKeys {
   static const String userId = "userId";
   static const String phone = "phone";
   static const String email = "email";
+  static const String username = "username";
   static const String encryptionKey = "encKey";
 }

--- a/mobile_frontend/lib/core/navigation/app_pages.dart
+++ b/mobile_frontend/lib/core/navigation/app_pages.dart
@@ -47,8 +47,14 @@ class AppPages {
             path: AppRoutes.home,
             builder: (context, state) {
               int page = state.extra != null ? state.extra as int : 0;
-              return BlocProvider(
-                create: (context) => getItInstance<MainCubit>(),
+              return MultiBlocProvider(
+                providers: [
+                  BlocProvider(create: (context) => getItInstance<MainCubit>()),
+                  BlocProvider(
+                    create: (context) =>
+                        getItInstance<ProfileCubit>()..loadProfile(),
+                  ),
+                ],
                 child: MainPage(initialPage: page),
               );
             },

--- a/mobile_frontend/lib/core/storage/local_data_source.dart
+++ b/mobile_frontend/lib/core/storage/local_data_source.dart
@@ -21,15 +21,23 @@ mixin LocalDataSource {
 
   Future<void> setVerified(bool value);
 
-  int getUserId();
+  String getUserId();
 
-  Future<void> setUserId(int id);
+  Future<void> setUserId(String id);
 
   Future<void> setLang(String val);
 
   Future<void> setUserFullName(String fullName);
 
   String getFullName();
+
+  Future<void> setUsername(String username);
+
+  String getUsername();
+
+  Future<void> setEmail(String email);
+
+  String getEmail();
 
 
   Future<void> setPhone(String phone);

--- a/mobile_frontend/lib/core/storage/local_data_source_impl.dart
+++ b/mobile_frontend/lib/core/storage/local_data_source_impl.dart
@@ -89,13 +89,37 @@ class LocalDataSourceImpl implements LocalDataSource {
   }
 
   @override
-  int getUserId() {
+  Future<void> setUsername(String username) async {
     final box = Hive.box(LocalStorageKeys.box);
-    return box.get(LocalStorageKeys.userId, defaultValue: 0);
+    await box.put(LocalStorageKeys.username, username);
   }
 
   @override
-  Future<void> setUserId(int id) async {
+  String getUsername() {
+    final box = Hive.box(LocalStorageKeys.box);
+    return box.get(LocalStorageKeys.username, defaultValue: "");
+  }
+
+  @override
+  Future<void> setEmail(String email) async {
+    final box = Hive.box(LocalStorageKeys.box);
+    await box.put(LocalStorageKeys.email, email);
+  }
+
+  @override
+  String getEmail() {
+    final box = Hive.box(LocalStorageKeys.box);
+    return box.get(LocalStorageKeys.email, defaultValue: "");
+  }
+
+  @override
+  String getUserId() {
+    final box = Hive.box(LocalStorageKeys.box);
+    return box.get(LocalStorageKeys.userId, defaultValue: "");
+  }
+
+  @override
+  Future<void> setUserId(String id) async {
     final box = Hive.box(LocalStorageKeys.box);
     await box.put(LocalStorageKeys.userId, id);
   }

--- a/mobile_frontend/lib/features/home/presentation/pages/home_page.dart
+++ b/mobile_frontend/lib/features/home/presentation/pages/home_page.dart
@@ -1,26 +1,34 @@
 import 'package:Finance/core/constants/app_colors.dart';
 import 'package:flutter/material.dart';
 
+import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../shared/presentation/widgets/appbar/w_main_appbar.dart';
 import '../../../../core/constants/app_images.dart';
+import '../../../profile/presentation/cubit/profile_cubit.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.background,
-      appBar: MainAppBar(
-        title: 'Home',
-        subtitle: 'Welcome back',
-        profileImage: AssetImage(AppImages.logo),
-        onTap: () {},
-        onNotificationTap: () {},
-      ),
-      body: const Center(
-        child: Text('Home Page'),
-      ),
+    return BlocBuilder<ProfileCubit, ProfileState>(
+      builder: (context, state) {
+        final profile = state.profile;
+        return Scaffold(
+          backgroundColor: AppColors.background,
+          appBar: MainAppBar(
+            firstName: profile?.username ?? '',
+            lastName: '',
+            username: profile?.username ?? '',
+            profileImage: const AssetImage(AppImages.logo),
+            onProfileTap: () {},
+            onNotificationTap: () {},
+          ),
+          body: const Center(
+            child: Text('Home Page'),
+          ),
+        );
+      },
     );
   }
 }

--- a/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
+++ b/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
@@ -8,7 +8,6 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import '../../../profile/presentation/pages/profile_page.dart';
 import '../../../profile/presentation/cubit/profile_cubit.dart';
 import '../../../home/presentation/pages/home_page.dart';
-import '../../../../core/di/get_it.dart';
 
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/constants/app_sizes.dart';
@@ -62,10 +61,13 @@ class _MainPageState extends State<MainPage> {
           body: IndexedStack(
             index: state.currentIndex,
             children: [
-              const HomePage(),
+              BlocProvider.value(
+                value: context.read<ProfileCubit>(),
+                child: const HomePage(),
+              ),
               Container(), // Replace with real screen
-              BlocProvider(
-                create: (context) => getItInstance<ProfileCubit>(),
+              BlocProvider.value(
+                value: context.read<ProfileCubit>(),
                 child: const ProfilePage(),
               ),
             ],

--- a/mobile_frontend/lib/features/profile/data/model/profile_response.dart
+++ b/mobile_frontend/lib/features/profile/data/model/profile_response.dart
@@ -1,10 +1,17 @@
 class ProfileResponse {
   final String id;
   final String username;
-  ProfileResponse({required this.id, required this.username});
+  final String email;
+
+  ProfileResponse({
+    required this.id,
+    required this.username,
+    required this.email,
+  });
 
   factory ProfileResponse.fromJson(Map<String, dynamic> json) => ProfileResponse(
         id: json['id']?.toString() ?? '',
         username: json['username'] as String? ?? '',
+        email: json['email'] as String? ?? '',
       );
 }

--- a/mobile_frontend/lib/features/profile/data/repository/profile_repository_impl.dart
+++ b/mobile_frontend/lib/features/profile/data/repository/profile_repository_impl.dart
@@ -16,8 +16,21 @@ class ProfileRepositoryImpl with ProfileRepository {
   Future<Either<Failure, ProfileResponse>> getProfile() async {
     try {
       final resp = await _client.getProfile();
+      await _localDataSource.setUserId(resp.id);
+      await _localDataSource.setUsername(resp.username);
+      await _localDataSource.setEmail(resp.email);
       return Right(resp);
     } catch (e) {
+      try {
+        final cached = ProfileResponse(
+          id: _localDataSource.getUserId(),
+          username: _localDataSource.getUsername(),
+          email: _localDataSource.getEmail(),
+        );
+        if (cached.id.isNotEmpty) {
+          return Right(cached);
+        }
+      } catch (_) {}
       return Left(Failure(errorMessage: e.toString()));
     }
   }

--- a/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
+++ b/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
@@ -25,24 +25,25 @@ class _ProfilePageState extends State<ProfilePage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: MainAppBar(
-        title: 'Profile',
-        subtitle: 'Your account',
-        profileImage: AssetImage(AppImages.logo),
-        onTap: () {},
-        onNotificationTap: () {},
-      ),
-      body: BlocBuilder<ProfileCubit, ProfileState>(
-        builder: (context, state) {
-          if (state.status.isLoading()) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          if (state.status.isError()) {
-            return Center(child: Text(state.errorMessage));
-          }
-          final p = state.profile;
-          return Padding(
+    return BlocBuilder<ProfileCubit, ProfileState>(
+      builder: (context, state) {
+        if (state.status.isLoading()) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (state.status.isError()) {
+          return Center(child: Text(state.errorMessage));
+        }
+        final p = state.profile;
+        return Scaffold(
+          appBar: MainAppBar(
+            firstName: p?.username ?? '',
+            lastName: '',
+            username: p?.username ?? '',
+            profileImage: const AssetImage(AppImages.logo),
+            onProfileTap: () {},
+            onNotificationTap: () {},
+          ),
+          body: Padding(
             padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -64,9 +65,9 @@ class _ProfilePageState extends State<ProfilePage> {
                 ),
               ],
             ),
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- cache username and email in local data source
- read profile from backend and cache results
- inject ProfileCubit on main route
- share ProfileCubit between pages
- show profile info in MainAppBar on Home and Profile pages

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: `Unable to locate package dart`)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873b46cf6f08327bc41d5d5b3e2b65a