### PR TITLE
Fix profile import and app images constants

### DIFF
--- a/mobile_frontend/lib/core/constants/app_images.dart
+++ b/mobile_frontend/lib/core/constants/app_images.dart
@@ -1,4 +1,4 @@
 class AppImages {
-  static String emptyImage = "assets/png/logo_welcome.png";
-  static String logo = "assets/png/logo_splash.png";
+  static const String emptyImage = 'assets/png/logo_welcome.png';
+  static const String logo = 'assets/png/logo_splash.png';
 }

--- a/mobile_frontend/lib/features/home/presentation/pages/home_page.dart
+++ b/mobile_frontend/lib/features/home/presentation/pages/home_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../shared/presentation/widgets/appbar/w_main_appbar.dart';
 import '../../../../core/constants/app_images.dart';
 import '../../../profile/presentation/cubit/profile_cubit.dart';
+import '../../../profile/presentation/cubit/profile_state.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});


### PR DESCRIPTION
## Summary
- add missing profile state import in `home_page.dart`
- make image paths constant in `AppImages` class

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873b7d7b2c08327a67b1ce3fb9c689a