### PR TITLE
Implement profile icon tap navigation

### DIFF
--- a/mobile_frontend/lib/features/home/presentation/pages/home_page.dart
+++ b/mobile_frontend/lib/features/home/presentation/pages/home_page.dart
@@ -6,6 +6,7 @@ import '../../../shared/presentation/widgets/appbar/w_main_appbar.dart';
 import '../../../../core/constants/app_images.dart';
 import '../../../profile/presentation/cubit/profile_cubit.dart';
 import '../../../profile/presentation/cubit/profile_state.dart';
+import '../../../shared/presentation/cubits/navigate/navigate_cubit.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
@@ -22,7 +23,8 @@ class HomePage extends StatelessWidget {
             lastName: profile?.lastName ?? '',
             username: profile?.username ?? '',
             profileImage: const AssetImage(AppImages.logo),
-            onProfileTap: () {},
+            onProfileTap: () =>
+                context.read<NavigateCubit>().goToProfilePage(),
             onNotificationTap: () {},
           ),
           body: const Center(

--- a/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
+++ b/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
@@ -6,6 +6,7 @@ import '../../../../core/themes/app_text_styles.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
 import '../../../shared/presentation/widgets/appbar/w_main_appbar.dart';
 import '../../../../core/constants/app_images.dart';
+import '../../../shared/presentation/cubits/navigate/navigate_cubit.dart';
 import '../cubit/profile_cubit.dart';
 import '../cubit/profile_state.dart';
 
@@ -46,7 +47,8 @@ class _ProfilePageState extends State<ProfilePage> {
             lastName: p?.lastName ?? '',
             username: p?.username ?? '',
             profileImage: const AssetImage(AppImages.logo),
-            onProfileTap: () {},
+            onProfileTap: () =>
+                context.read<NavigateCubit>().goToProfilePage(),
             onNotificationTap: () {},
           ),
           body: Padding(

--- a/mobile_frontend/lib/features/shared/presentation/cubits/navigate/navigate_cubit.dart
+++ b/mobile_frontend/lib/features/shared/presentation/cubits/navigate/navigate_cubit.dart
@@ -28,4 +28,8 @@ class NavigateCubit extends Cubit<NavigateState> {
   void goToForgotPasswordPage() {
     _navigationService.navigateTo(AppRoutes.forgotPassword);
   }
+
+  void goToProfilePage() {
+    _navigationService.navigateTo(AppRoutes.profile);
+  }
 }

--- a/mobile_frontend/lib/features/shared/presentation/widgets/appbar/w_main_appbar.dart
+++ b/mobile_frontend/lib/features/shared/presentation/widgets/appbar/w_main_appbar.dart
@@ -53,7 +53,7 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
             GestureDetector(
               onTap: onProfileTap,
               child: CircleAvatar(
-                radius: 24,
+                radius: 30,
                 backgroundImage: profileImage,
               ),
             ),


### PR DESCRIPTION
## Summary
- route to profile page when tapping profile avatar
- add helper method in `NavigateCubit` to navigate to profile
- increase avatar radius to match notification button size

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6873cd7b0cdc8327a60e88ca351cdd00