### PR TITLE
Fix profile photo asset logic

### DIFF
--- a/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
+++ b/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
@@ -64,8 +64,8 @@ class _ProfilePageState extends State<ProfilePage> {
                     ImageProvider provider;
                     final path = p.profileImage;
                     if (path != null && path.isNotEmpty) {
-                      if (path.startsWith('assets/')) {
-                        provider = AssetImage(path);
+                      if (path == AppImages.profileDefault) {
+                        provider = const AssetImage(AppImages.profileDefault);
                       } else {
                         provider = NetworkImage(
                           "${AppApi.baseUrlProd}/$path",


### PR DESCRIPTION
## Summary
- fix profile page so uploaded profile photos load via network

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873f840f8c88327825a6be059fbc842