### PR TITLE
Fix profile page asset logic

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,9 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.utils import get_openapi
+from fastapi.staticfiles import StaticFiles
+
+import config
 
 from api.v1.auth import router as auth_router
 
@@ -8,6 +11,13 @@ app = FastAPI(
     title="Personal Budget API",
     description="API для приложения личного бюджета (FastAPI, PostgreSQL, Redis)",
     version="1.0.0"
+)
+
+# Serve static files such as uploaded profile images
+app.mount(
+    "/assets",
+    StaticFiles(directory=config.BASE_DIR / "mobile_frontend" / "assets"),
+    name="assets",
 )
 
 def custom_openapi():

--- a/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
+++ b/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
@@ -64,8 +64,8 @@ class _ProfilePageState extends State<ProfilePage> {
                     ImageProvider provider;
                     final path = p.profileImage;
                     if (path != null && path.isNotEmpty) {
-                      if (path.startsWith('assets/')) {
-                        provider = AssetImage(path);
+                      if (path == AppImages.profileDefault) {
+                        provider = const AssetImage(AppImages.profileDefault);
                       } else {
                         provider = NetworkImage(
                           "${AppApi.baseUrlProd}/$path",


### PR DESCRIPTION
## Summary
- serve uploaded profile images from `/assets`

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6873f840f8c88327825a6be059fbc842