### PR TITLE
Add TOTP page and edit name page

### DIFF
--- a/mobile_frontend/lib/core/constants/app_routes.dart
+++ b/mobile_frontend/lib/core/constants/app_routes.dart
@@ -6,6 +6,8 @@ class AppRoutes {
   static const String splashScreen = '/';
   static const String settings = '/settings';
   static const String profile = '/profile';
+  static const String totp = '/totp';
+  static const String editName = '/edit-name';
 
 
 

--- a/mobile_frontend/lib/core/di/cubits_init.dart
+++ b/mobile_frontend/lib/core/di/cubits_init.dart
@@ -10,6 +10,11 @@ import '../../features/profile/domain/usecase/logout_user.dart';
 import '../../features/profile/domain/usecase/update_profile.dart';
 import '../../features/profile/domain/usecase/upload_profile_image.dart';
 import '../../features/profile/presentation/cubit/profile_cubit.dart';
+import '../../features/profile/presentation/cubit/totp_cubit.dart';
+import '../../features/profile/domain/usecase/totp/get_totp_status.dart';
+import '../../features/profile/domain/usecase/totp/enable_totp.dart';
+import '../../features/profile/domain/usecase/totp/confirm_totp.dart';
+import '../../features/profile/domain/usecase/totp/disable_totp.dart';
 import 'get_it.dart';
 
 Future<void> cubitsInit() async {
@@ -32,6 +37,15 @@ Future<void> cubitsInit() async {
       getItInstance<UpdateProfile>(),
       getItInstance<UploadProfileImage>(),
       getItInstance<NavigateCubit>(),
+    ),
+  );
+
+  getItInstance.registerFactory<TotpCubit>(
+    () => TotpCubit(
+      getItInstance<GetTotpStatus>(),
+      getItInstance<EnableTotp>(),
+      getItInstance<ConfirmTotp>(),
+      getItInstance<DisableTotp>(),
     ),
   );
 }

--- a/mobile_frontend/lib/core/di/repositories_init.dart
+++ b/mobile_frontend/lib/core/di/repositories_init.dart
@@ -11,6 +11,12 @@ import '../../features/profile/domain/usecase/get_profile.dart';
 import '../../features/profile/domain/usecase/logout_user.dart';
 import '../../features/profile/domain/usecase/update_profile.dart';
 import '../../features/profile/domain/usecase/upload_profile_image.dart';
+import '../../features/profile/domain/usecase/totp/get_totp_status.dart';
+import '../../features/profile/domain/usecase/totp/enable_totp.dart';
+import '../../features/profile/domain/usecase/totp/confirm_totp.dart';
+import '../../features/profile/domain/usecase/totp/disable_totp.dart';
+import '../../features/profile/domain/repository/totp_repository.dart';
+import '../../features/profile/data/repository/totp_repository_impl.dart';
 import '../navigation/app_pages.dart';
 import '../navigation/navigation_service.dart';
 import '../network/api_client.dart';
@@ -81,5 +87,25 @@ Future<void> repositoriesInit() async {
 
   getItInstance.registerLazySingleton<UploadProfileImage>(
     () => UploadProfileImage(getItInstance<ProfileRepository>()),
+  );
+
+  getItInstance.registerLazySingleton<TotpRepository>(
+    () => TotpRepositoryImpl(getItInstance<ApiClient>()),
+  );
+
+  getItInstance.registerLazySingleton<GetTotpStatus>(
+    () => GetTotpStatus(getItInstance<TotpRepository>()),
+  );
+
+  getItInstance.registerLazySingleton<EnableTotp>(
+    () => EnableTotp(getItInstance<TotpRepository>()),
+  );
+
+  getItInstance.registerLazySingleton<ConfirmTotp>(
+    () => ConfirmTotp(getItInstance<TotpRepository>()),
+  );
+
+  getItInstance.registerLazySingleton<DisableTotp>(
+    () => DisableTotp(getItInstance<TotpRepository>()),
   );
 }

--- a/mobile_frontend/lib/core/navigation/app_pages.dart
+++ b/mobile_frontend/lib/core/navigation/app_pages.dart
@@ -13,6 +13,9 @@ import '../../features/main/cubits/main/main_cubit.dart';
 import '../../features/auth/presentation/cubit/login/login_cubit.dart';
 import '../../features/profile/presentation/pages/profile_page.dart';
 import '../../features/profile/presentation/cubit/profile_cubit.dart';
+import '../../features/profile/presentation/cubit/totp_cubit.dart';
+import '../../features/profile/presentation/pages/totp_page.dart';
+import '../../features/profile/presentation/pages/edit_name_page.dart';
 import '../constants/app_routes.dart';
 import '../di/get_it.dart';
 
@@ -74,6 +77,52 @@ class AppPages {
               transitionsBuilder:
                   (context, animation, secondaryAnimation, child) {
                 const begin = Offset(-1.0, 0.0);
+                const end = Offset.zero;
+                final tween = Tween(begin: begin, end: end).chain(
+                  CurveTween(curve: Curves.easeInOut),
+                );
+                return SlideTransition(
+                  position: animation.drive(tween),
+                  child: child,
+                );
+              },
+            ),
+          ),
+
+          GoRoute(
+            path: AppRoutes.totp,
+            pageBuilder: (context, state) => CustomTransitionPage(
+              key: state.pageKey,
+              child: BlocProvider(
+                create: (context) => getItInstance<TotpCubit>(),
+                child: const TotpPage(),
+              ),
+              transitionsBuilder:
+                  (context, animation, secondaryAnimation, child) {
+                const begin = Offset(1.0, 0.0);
+                const end = Offset.zero;
+                final tween = Tween(begin: begin, end: end).chain(
+                  CurveTween(curve: Curves.easeInOut),
+                );
+                return SlideTransition(
+                  position: animation.drive(tween),
+                  child: child,
+                );
+              },
+            ),
+          ),
+
+          GoRoute(
+            path: AppRoutes.editName,
+            pageBuilder: (context, state) => CustomTransitionPage(
+              key: state.pageKey,
+              child: BlocProvider(
+                create: (context) => getItInstance<ProfileCubit>(),
+                child: const EditNamePage(),
+              ),
+              transitionsBuilder:
+                  (context, animation, secondaryAnimation, child) {
+                const begin = Offset(1.0, 0.0);
                 const end = Offset.zero;
                 final tween = Tween(begin: begin, end: end).chain(
                   CurveTween(curve: Curves.easeInOut),

--- a/mobile_frontend/lib/core/network/api_client.dart
+++ b/mobile_frontend/lib/core/network/api_client.dart
@@ -9,6 +9,9 @@ import '../../features/auth/data/model/response/login_user_response.dart';
 import '../../features/profile/data/model/profile_response.dart';
 import '../../features/profile/data/model/logout_request.dart';
 import '../../features/profile/data/model/update_profile_request.dart';
+import '../../features/profile/data/model/totp_setup_response.dart';
+import '../../features/profile/data/model/totp_status_response.dart';
+import '../../features/profile/data/model/totp_code_request.dart';
 import '../../features/auth/data/model/request/refresh_token_request.dart';
 import '../constants/app_api.dart';
 import '../constants/app_constants.dart';
@@ -126,6 +129,18 @@ abstract class ApiClient {
 
   @POST(AppApi.logout)
   Future<void> logout(@Body() LogoutRequest request);
+
+  @GET(AppApi.totp_status)
+  Future<TotpStatusResponse> totpStatus();
+
+  @POST(AppApi.totp_enable)
+  Future<TotpSetupResponse> enableTotp();
+
+  @POST(AppApi.totp_confirm)
+  Future<void> confirmTotp(@Body() TotpCodeRequest request);
+
+  @POST(AppApi.totp_disable)
+  Future<void> disableTotp(@Body() TotpCodeRequest request);
 
 
 }

--- a/mobile_frontend/lib/core/network/api_client.g.dart
+++ b/mobile_frontend/lib/core/network/api_client.g.dart
@@ -211,6 +211,121 @@ class _ApiClient implements ApiClient {
     await _dio.fetch<void>(_options);
   }
 
+  @override
+  Future<TotpStatusResponse> totpStatus() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    final _options = _setStreamType<TotpStatusResponse>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '/auth/totp-status',
+          queryParameters: queryParameters,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late TotpStatusResponse _value;
+    try {
+      _value = TotpStatusResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<TotpSetupResponse> enableTotp() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    final _options = _setStreamType<TotpSetupResponse>(Options(
+      method: 'POST',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '/auth/enable-totp',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    final _result = await _dio.fetch<Map<String, dynamic>>(_options);
+    late TotpSetupResponse _value;
+    try {
+      _value = TotpSetupResponse.fromJson(_result.data!);
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<void> confirmTotp(TotpCodeRequest request) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = request.toJson();
+    final _options = _setStreamType<void>(Options(
+      method: 'POST',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '/auth/confirm-totp',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    await _dio.fetch<void>(_options);
+  }
+
+  @override
+  Future<void> disableTotp(TotpCodeRequest request) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = request.toJson();
+    final _options = _setStreamType<void>(Options(
+      method: 'POST',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '/auth/disable-totp',
+          queryParameters: queryParameters,
+          data: _data,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    await _dio.fetch<void>(_options);
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/mobile_frontend/lib/features/profile/data/model/totp_code_request.dart
+++ b/mobile_frontend/lib/features/profile/data/model/totp_code_request.dart
@@ -1,0 +1,6 @@
+class TotpCodeRequest {
+  final String code;
+  TotpCodeRequest({required this.code});
+
+  Map<String, dynamic> toJson() => {'code': code};
+}

--- a/mobile_frontend/lib/features/profile/data/model/totp_setup_response.dart
+++ b/mobile_frontend/lib/features/profile/data/model/totp_setup_response.dart
@@ -1,0 +1,11 @@
+class TotpSetupResponse {
+  final String otpauthUri;
+  final String qrPngBase64;
+
+  TotpSetupResponse({required this.otpauthUri, required this.qrPngBase64});
+
+  factory TotpSetupResponse.fromJson(Map<String, dynamic> json) => TotpSetupResponse(
+        otpauthUri: json['otpauth_uri'] as String? ?? '',
+        qrPngBase64: json['qr_png_base64'] as String? ?? '',
+      );
+}

--- a/mobile_frontend/lib/features/profile/data/model/totp_status_response.dart
+++ b/mobile_frontend/lib/features/profile/data/model/totp_status_response.dart
@@ -1,0 +1,8 @@
+class TotpStatusResponse {
+  final bool isEnabled;
+
+  TotpStatusResponse({required this.isEnabled});
+
+  factory TotpStatusResponse.fromJson(Map<String, dynamic> json) =>
+      TotpStatusResponse(isEnabled: json['is_enabled'] as bool? ?? false);
+}

--- a/mobile_frontend/lib/features/profile/data/repository/totp_repository_impl.dart
+++ b/mobile_frontend/lib/features/profile/data/repository/totp_repository_impl.dart
@@ -1,0 +1,53 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/network/api_client.dart';
+import '../../../../core/network/failure.dart';
+import '../../domain/repository/totp_repository.dart';
+import '../model/totp_code_request.dart';
+import '../model/totp_setup_response.dart';
+import '../model/totp_status_response.dart';
+
+class TotpRepositoryImpl with TotpRepository {
+  final ApiClient _client;
+  TotpRepositoryImpl(this._client);
+
+  @override
+  Future<Either<Failure, TotpStatusResponse>> status() async {
+    try {
+      final resp = await _client.totpStatus();
+      return Right(resp);
+    } catch (e) {
+      return Left(Failure(errorMessage: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, TotpSetupResponse>> enable() async {
+    try {
+      final resp = await _client.enableTotp();
+      return Right(resp);
+    } catch (e) {
+      return Left(Failure(errorMessage: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> confirm(String code) async {
+    try {
+      await _client.confirmTotp(TotpCodeRequest(code: code));
+      return const Right(null);
+    } catch (e) {
+      return Left(Failure(errorMessage: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> disable(String code) async {
+    try {
+      await _client.disableTotp(TotpCodeRequest(code: code));
+      return const Right(null);
+    } catch (e) {
+      return Left(Failure(errorMessage: e.toString()));
+    }
+  }
+}

--- a/mobile_frontend/lib/features/profile/domain/repository/totp_repository.dart
+++ b/mobile_frontend/lib/features/profile/domain/repository/totp_repository.dart
@@ -1,0 +1,11 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/network/failure.dart';
+import '../../data/model/totp_status_response.dart';
+import '../../data/model/totp_setup_response.dart';
+
+mixin TotpRepository {
+  Future<Either<Failure, TotpStatusResponse>> status();
+  Future<Either<Failure, TotpSetupResponse>> enable();
+  Future<Either<Failure, void>> confirm(String code);
+  Future<Either<Failure, void>> disable(String code);
+}

--- a/mobile_frontend/lib/features/profile/domain/usecase/totp/confirm_totp.dart
+++ b/mobile_frontend/lib/features/profile/domain/usecase/totp/confirm_totp.dart
@@ -1,0 +1,19 @@
+import 'package:dartz/dartz.dart';
+import '../../../../../core/network/failure.dart';
+import '../../../../../core/network/use_case.dart';
+import '../../repository/totp_repository.dart';
+
+class ConfirmTotp extends UseCase<void, ConfirmTotpParams> {
+  final TotpRepository _repository;
+  ConfirmTotp(this._repository);
+
+  @override
+  Future<Either<Failure, void>> call(ConfirmTotpParams params) {
+    return _repository.confirm(params.code);
+  }
+}
+
+class ConfirmTotpParams {
+  final String code;
+  ConfirmTotpParams(this.code);
+}

--- a/mobile_frontend/lib/features/profile/domain/usecase/totp/disable_totp.dart
+++ b/mobile_frontend/lib/features/profile/domain/usecase/totp/disable_totp.dart
@@ -1,0 +1,19 @@
+import 'package:dartz/dartz.dart';
+import '../../../../../core/network/failure.dart';
+import '../../../../../core/network/use_case.dart';
+import '../../repository/totp_repository.dart';
+
+class DisableTotp extends UseCase<void, DisableTotpParams> {
+  final TotpRepository _repository;
+  DisableTotp(this._repository);
+
+  @override
+  Future<Either<Failure, void>> call(DisableTotpParams params) {
+    return _repository.disable(params.code);
+  }
+}
+
+class DisableTotpParams {
+  final String code;
+  DisableTotpParams(this.code);
+}

--- a/mobile_frontend/lib/features/profile/domain/usecase/totp/enable_totp.dart
+++ b/mobile_frontend/lib/features/profile/domain/usecase/totp/enable_totp.dart
@@ -1,0 +1,16 @@
+import 'package:dartz/dartz.dart';
+import '../../../../../core/network/failure.dart';
+import '../../../../../core/network/use_case.dart';
+import '../../repository/totp_repository.dart';
+import '../../../data/model/totp_setup_response.dart';
+import '../../../../../core/network/no_params.dart';
+
+class EnableTotp extends UseCase<TotpSetupResponse, NoParams> {
+  final TotpRepository _repository;
+  EnableTotp(this._repository);
+
+  @override
+  Future<Either<Failure, TotpSetupResponse>> call(NoParams params) {
+    return _repository.enable();
+  }
+}

--- a/mobile_frontend/lib/features/profile/domain/usecase/totp/get_totp_status.dart
+++ b/mobile_frontend/lib/features/profile/domain/usecase/totp/get_totp_status.dart
@@ -1,0 +1,16 @@
+import 'package:dartz/dartz.dart';
+import '../../../../../core/network/failure.dart';
+import '../../../../../core/network/use_case.dart';
+import '../../repository/totp_repository.dart';
+import '../../../data/model/totp_status_response.dart';
+import '../../../../../core/network/no_params.dart';
+
+class GetTotpStatus extends UseCase<TotpStatusResponse, NoParams> {
+  final TotpRepository _repository;
+  GetTotpStatus(this._repository);
+
+  @override
+  Future<Either<Failure, TotpStatusResponse>> call(NoParams params) {
+    return _repository.status();
+  }
+}

--- a/mobile_frontend/lib/features/profile/presentation/cubit/totp_cubit.dart
+++ b/mobile_frontend/lib/features/profile/presentation/cubit/totp_cubit.dart
@@ -1,0 +1,94 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/helpers/enums_helpers.dart';
+import '../../domain/usecase/totp/get_totp_status.dart';
+import '../../domain/usecase/totp/enable_totp.dart';
+import '../../domain/usecase/totp/confirm_totp.dart';
+import '../../domain/usecase/totp/disable_totp.dart';
+import '../../domain/usecase/totp/confirm_totp.dart' as c;
+import '../../domain/usecase/totp/disable_totp.dart' as d;
+import '../../domain/usecase/totp/get_totp_status.dart' as s;
+import '../../domain/usecase/totp/enable_totp.dart' as e;
+import '../../../../core/network/no_params.dart';
+
+class TotpState extends Equatable {
+  final RequestStatus status;
+  final bool isEnabled;
+  final bool awaitingConfirmation;
+  final String qr;
+  final String errorMessage;
+
+  const TotpState({
+    this.status = RequestStatus.initial,
+    this.isEnabled = false,
+    this.awaitingConfirmation = false,
+    this.qr = '',
+    this.errorMessage = '',
+  });
+
+  TotpState copyWith({
+    RequestStatus? status,
+    bool? isEnabled,
+    bool? awaitingConfirmation,
+    String? qr,
+    String? errorMessage,
+  }) {
+    return TotpState(
+      status: status ?? this.status,
+      isEnabled: isEnabled ?? this.isEnabled,
+      awaitingConfirmation: awaitingConfirmation ?? this.awaitingConfirmation,
+      qr: qr ?? this.qr,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, isEnabled, awaitingConfirmation, qr, errorMessage];
+}
+
+class TotpCubit extends Cubit<TotpState> {
+  final s.GetTotpStatus _status;
+  final e.EnableTotp _enable;
+  final c.ConfirmTotp _confirm;
+  final d.DisableTotp _disable;
+
+  TotpCubit(this._status, this._enable, this._confirm, this._disable)
+      : super(const TotpState());
+
+  Future<void> loadStatus() async {
+    emit(state.copyWith(status: RequestStatus.loading));
+    final result = await _status(const NoParams());
+    result.fold(
+      (failure) => emit(state.copyWith(status: RequestStatus.error, errorMessage: failure.errorMessage)),
+      (data) => emit(state.copyWith(status: RequestStatus.loaded, isEnabled: data.isEnabled)),
+    );
+  }
+
+  Future<void> enable() async {
+    emit(state.copyWith(status: RequestStatus.loading));
+    final result = await _enable(const NoParams());
+    result.fold(
+      (failure) => emit(state.copyWith(status: RequestStatus.error, errorMessage: failure.errorMessage)),
+      (data) => emit(state.copyWith(status: RequestStatus.loaded, awaitingConfirmation: true, qr: data.qrPngBase64)),
+    );
+  }
+
+  Future<void> confirm(String code) async {
+    emit(state.copyWith(status: RequestStatus.loading));
+    final result = await _confirm(c.ConfirmTotpParams(code));
+    result.fold(
+      (failure) => emit(state.copyWith(status: RequestStatus.error, errorMessage: failure.errorMessage)),
+      (_) => emit(state.copyWith(status: RequestStatus.loaded, isEnabled: true, awaitingConfirmation: false, qr: '')),
+    );
+  }
+
+  Future<void> disable(String code) async {
+    emit(state.copyWith(status: RequestStatus.loading));
+    final result = await _disable(d.DisableTotpParams(code));
+    result.fold(
+      (failure) => emit(state.copyWith(status: RequestStatus.error, errorMessage: failure.errorMessage)),
+      (_) => emit(state.copyWith(status: RequestStatus.loaded, isEnabled: false)),
+    );
+  }
+}

--- a/mobile_frontend/lib/features/profile/presentation/pages/edit_name_page.dart
+++ b/mobile_frontend/lib/features/profile/presentation/pages/edit_name_page.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/constants/app_colors.dart';
+import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
+import '../../../shared/presentation/widgets/appbar/w_inner_appbar.dart';
+import '../cubit/profile_cubit.dart';
+import '../cubit/profile_state.dart';
+
+class EditNamePage extends StatefulWidget {
+  const EditNamePage({super.key});
+
+  @override
+  State<EditNamePage> createState() => _EditNamePageState();
+}
+
+class _EditNamePageState extends State<EditNamePage> {
+  final _firstNameController = TextEditingController();
+  final _lastNameController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<ProfileCubit>().loadProfile();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileCubit, ProfileState>(
+      builder: (context, state) {
+        if (state.profile != null) {
+          _firstNameController.text = state.profile!.firstName;
+          _lastNameController.text = state.profile!.lastName;
+        }
+        return Scaffold(
+          backgroundColor: AppColors.background,
+          appBar: SubpageAppBar(
+            title: 'Edit name',
+            onBackTap: () => Navigator.of(context).pop(),
+          ),
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                TextField(
+                  controller: _firstNameController,
+                  decoration: const InputDecoration(labelText: 'First Name'),
+                ),
+                TextField(
+                  controller: _lastNameController,
+                  decoration: const InputDecoration(labelText: 'Last Name'),
+                ),
+                const Spacer(),
+                WButton(
+                  onTap: () {
+                    context.read<ProfileCubit>().updateName(
+                          _firstNameController.text,
+                          _lastNameController.text,
+                        );
+                    Navigator.of(context).pop();
+                  },
+                  text: 'Save',
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
+++ b/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
@@ -21,8 +21,6 @@ class ProfilePage extends StatefulWidget {
 }
 
 class _ProfilePageState extends State<ProfilePage> {
-  final _firstNameController = TextEditingController();
-  final _lastNameController = TextEditingController();
   final _picker = ImagePicker();
   @override
   void initState() {
@@ -41,10 +39,6 @@ class _ProfilePageState extends State<ProfilePage> {
           return Center(child: Text(state.errorMessage));
         }
         final p = state.profile;
-        if (p != null) {
-          _firstNameController.text = p.firstName;
-          _lastNameController.text = p.lastName;
-        }
         return Scaffold(
           backgroundColor: AppColors.background,
           appBar: SubpageAppBar(
@@ -135,15 +129,6 @@ class _ProfilePageState extends State<ProfilePage> {
                       ),
                     ],
                   ),
-                  const SizedBox(height: 8),
-                  TextField(
-                    controller: _firstNameController,
-                    decoration: const InputDecoration(labelText: 'First Name'),
-                  ),
-                  TextField(
-                    controller: _lastNameController,
-                    decoration: const InputDecoration(labelText: 'Last Name'),
-                  ),
                 ],
                 const Spacer(),
                 WButton(
@@ -152,10 +137,13 @@ class _ProfilePageState extends State<ProfilePage> {
                 ),
                 const SizedBox(height: 8),
                 WButton(
-                  onTap: () => context
-                      .read<ProfileCubit>()
-                      .updateName(_firstNameController.text, _lastNameController.text),
-                  text: 'Save',
+                  onTap: () => context.read<NavigateCubit>().goToEditNamePage(),
+                  text: 'Edit name',
+                ),
+                const SizedBox(height: 8),
+                WButton(
+                  onTap: () => context.read<NavigateCubit>().goToTotpPage(),
+                  text: 'Two-factor auth',
                 ),
               ],
             ),

--- a/mobile_frontend/lib/features/profile/presentation/pages/totp_page.dart
+++ b/mobile_frontend/lib/features/profile/presentation/pages/totp_page.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/constants/app_colors.dart';
+import '../../../shared/presentation/widgets/appbar/w_inner_appbar.dart';
+import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
+import '../cubit/totp_cubit.dart';
+
+class TotpPage extends StatefulWidget {
+  const TotpPage({super.key});
+
+  @override
+  State<TotpPage> createState() => _TotpPageState();
+}
+
+class _TotpPageState extends State<TotpPage> {
+  final _codeController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    context.read<TotpCubit>().loadStatus();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<TotpCubit, TotpState>(
+      builder: (context, state) {
+        Widget body;
+        if (state.status.isLoading()) {
+          body = const Center(child: CircularProgressIndicator());
+        } else if (state.status.isError()) {
+          body = Center(child: Text(state.errorMessage));
+        } else if (state.isEnabled) {
+          body = Column(
+            children: [
+              const Text('TOTP is enabled'),
+              TextField(
+                controller: _codeController,
+                decoration: const InputDecoration(labelText: 'Code'),
+              ),
+              const SizedBox(height: 16),
+              WButton(
+                onTap: () =>
+                    context.read<TotpCubit>().disable(_codeController.text),
+                text: 'Disable',
+              ),
+            ],
+          );
+        } else if (state.awaitingConfirmation) {
+          body = Column(
+            children: [
+              if (state.qr.isNotEmpty)
+                Image.memory(base64Decode(state.qr)),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _codeController,
+                decoration: const InputDecoration(labelText: 'Code'),
+              ),
+              const SizedBox(height: 16),
+              WButton(
+                onTap: () =>
+                    context.read<TotpCubit>().confirm(_codeController.text),
+                text: 'Confirm',
+              ),
+            ],
+          );
+        } else {
+          body = WButton(
+            onTap: () => context.read<TotpCubit>().enable(),
+            text: 'Enable TOTP',
+          );
+        }
+
+        return Scaffold(
+          backgroundColor: AppColors.background,
+          appBar: SubpageAppBar(
+            title: 'TOTP',
+            onBackTap: () => Navigator.of(context).pop(),
+          ),
+          body: Padding(
+            padding: const EdgeInsets.all(16),
+            child: body,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/mobile_frontend/lib/features/shared/presentation/cubits/navigate/navigate_cubit.dart
+++ b/mobile_frontend/lib/features/shared/presentation/cubits/navigate/navigate_cubit.dart
@@ -32,4 +32,12 @@ class NavigateCubit extends Cubit<NavigateState> {
   void goToProfilePage() {
     _navigationService.navigateTo(AppRoutes.profile);
   }
+
+  void goToTotpPage() {
+    _navigationService.pushTo(AppRoutes.totp);
+  }
+
+  void goToEditNamePage() {
+    _navigationService.pushTo(AppRoutes.editName);
+  }
 }


### PR DESCRIPTION
## Summary
- create TOTP management page with cubit and repository
- create page for editing first and last name
- update navigation routes and cubits
- extend API client with TOTP endpoints
- wire new dependencies in DI
- update profile page buttons to open new pages

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874288def388327a8dc2832d3930979