### PR TITLE
Fix logout button layout on profile page

### DIFF
--- a/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
+++ b/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
@@ -130,12 +130,7 @@ class _ProfilePageState extends State<ProfilePage> {
                     ],
                   ),
                 ],
-                const Spacer(),
-                WButton(
-                  onTap: () => context.read<ProfileCubit>().logout(),
-                  text: 'Logout',
-                ),
-                const SizedBox(height: 8),
+                const SizedBox(height: 16),
                 WButton(
                   onTap: () => context.read<NavigateCubit>().goToEditNamePage(),
                   text: 'Edit name',
@@ -144,6 +139,11 @@ class _ProfilePageState extends State<ProfilePage> {
                 WButton(
                   onTap: () => context.read<NavigateCubit>().goToTotpPage(),
                   text: 'Two-factor auth',
+                ),
+                const Spacer(),
+                WButton(
+                  onTap: () => context.read<ProfileCubit>().logout(),
+                  text: 'Logout',
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- update profile page layout to keep logout button at bottom

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68742f2164b883279b77609b4d50e770