### PR TITLE
Use black buttons on profile page

### DIFF
--- a/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
+++ b/mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart
@@ -10,6 +10,7 @@ import '../../../../core/themes/app_text_styles.dart';
 import '../../../../core/constants/app_images.dart';
 import '../../../../core/constants/app_api.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
+import '../../../shared/presentation/widgets/app_buttons/w_button_black.dart';
 import '../../../shared/presentation/widgets/appbar/w_inner_appbar.dart';
 import '../../../shared/presentation/cubits/navigate/navigate_cubit.dart';
 import '../cubit/profile_cubit.dart';
@@ -133,14 +134,16 @@ class _ProfilePageState extends State<ProfilePage> {
                   ),
                 ],
                 const SizedBox(height: 16),
-                WButton(
-                  onTap: () => context.read<NavigateCubit>().goToEditNamePage(),
-                  text: 'Edit name',
+                TaskCardButton(
+                  title: 'Edit name',
+                  subtitle: '',
+                  onArrowTap: () =>
+                      context.read<NavigateCubit>().goToEditNamePage(),
                 ),
-                const SizedBox(height: 8),
-                WButton(
-                  onTap: () => context.read<NavigateCubit>().goToTotpPage(),
-                  text: 'Two-factor auth',
+                TaskCardButton(
+                  title: 'Two-factor auth',
+                  subtitle: '',
+                  onArrowTap: () => context.read<NavigateCubit>().goToTotpPage(),
                 ),
                 const Spacer(),
                 WButton(


### PR DESCRIPTION
## Summary
- update profile page to use `w_button_black` for first two actions

## Testing
- `dart format --output=none mobile_frontend/lib/features/profile/presentation/pages/profile_page.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687434d6d9cc832783c7945cd332900d