### PR TITLE
Add budget page to navbar

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/budget_page.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/budget_page.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/constants/app_colors.dart';
+
+class BudgetPage extends StatelessWidget {
+  const BudgetPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      backgroundColor: AppColors.background,
+      body: Center(
+        child: Text('Budget Page'),
+      ),
+    );
+  }
+}

--- a/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
+++ b/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import '../../../profile/presentation/cubit/profile_cubit.dart';
 import '../../../home/presentation/pages/home_page.dart';
+import '../../../budget/presentation/pages/budget_page.dart';
 
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/constants/app_sizes.dart';
@@ -64,7 +65,7 @@ class _MainPageState extends State<MainPage> {
                 value: context.read<ProfileCubit>(),
                 child: const HomePage(),
               ),
-              Container(), // Replace with real screen
+              const BudgetPage(),
             ],
           ),
           bottomNavigationBar: CurvedBottomNavbar(
@@ -77,8 +78,8 @@ class _MainPageState extends State<MainPage> {
                 label: '',
               ),
               BottomNavigationBarItem(
-                icon: Icon(Icons.insert_chart_outlined),
-                activeIcon: Icon(Icons.insert_chart),
+                icon: Icon(Icons.account_balance_wallet_outlined),
+                activeIcon: Icon(Icons.account_balance_wallet),
                 label: '',
               ),
             ],


### PR DESCRIPTION
## Summary
- add a new `BudgetPage`
- show the budget page in MainPage's IndexedStack
- add budget tab to bottom navigation

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68754e00818c832782fd6cb051586eb2