### PR TITLE
Load transactions from backend

### DIFF
--- a/app/api/v1/transactions.py
+++ b/app/api/v1/transactions.py
@@ -1,0 +1,28 @@
+from datetime import datetime, date, timedelta
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from database import get_session
+from models.transactions import Transaction
+from models.users import User
+import services.auth_service as auth_service
+from schemas.transaction import TransactionRead
+
+router = APIRouter(prefix="/transactions", tags=["Transactions"])
+
+@router.get("", response_model=list[TransactionRead])
+async def transactions_by_date(
+    date: date,
+    user: User = Depends(auth_service.get_current_user),
+    session: AsyncSession = Depends(get_session),
+):
+    start = datetime.combine(date, datetime.min.time())
+    end = start + timedelta(days=1)
+    stmt = select(Transaction).where(
+        Transaction.user_id == user.id,
+        Transaction.created_at >= start,
+        Transaction.created_at < end,
+    ).order_by(Transaction.created_at.desc())
+    result = await session.scalars(stmt)
+    return list(result)

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from fastapi.staticfiles import StaticFiles
 import config
 
 from api.v1.auth import router as auth_router
+from api.v1.transactions import router as transactions_router
 
 app = FastAPI(
     title="Personal Budget API",
@@ -46,6 +47,7 @@ app.add_middleware(
 
 # Register routers
 app.include_router(auth_router)
+app.include_router(transactions_router)
 
 
 

--- a/app/schemas/transaction.py
+++ b/app/schemas/transaction.py
@@ -1,0 +1,12 @@
+import uuid
+from datetime import datetime
+from pydantic import BaseModel
+
+class TransactionRead(BaseModel):
+    id: uuid.UUID
+    account_id: uuid.UUID
+    amount: int
+    description: str | None = None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/mobile_frontend/lib/core/constants/app_api.dart
+++ b/mobile_frontend/lib/core/constants/app_api.dart
@@ -12,6 +12,7 @@ class AppApi{
   static const me = "/auth/me";
   static const r_token = "/auth/refresh";
   static const profileImage = "/auth/profile-image";
+  static const transactions = "/transactions";
 
   // static const orderStatus = "/order-status";
   // static const regions = "/regions";

--- a/mobile_frontend/lib/core/di/cubits_init.dart
+++ b/mobile_frontend/lib/core/di/cubits_init.dart
@@ -16,6 +16,8 @@ import '../../features/profile/domain/usecase/totp/enable_totp.dart';
 import '../../features/profile/domain/usecase/totp/confirm_totp.dart';
 import '../../features/profile/domain/usecase/totp/disable_totp.dart';
 import 'get_it.dart';
+import '../../features/budget/presentation/cubit/budget_cubit.dart';
+import '../../features/budget/domain/usecase/get_transactions_by_date.dart';
 
 Future<void> cubitsInit() async {
   getItInstance.registerFactory<SplashCubit>(
@@ -46,6 +48,12 @@ Future<void> cubitsInit() async {
       getItInstance<EnableTotp>(),
       getItInstance<ConfirmTotp>(),
       getItInstance<DisableTotp>(),
+    ),
+  );
+
+  getItInstance.registerFactory<BudgetCubit>(
+    () => BudgetCubit(
+      getItInstance<GetTransactionsByDate>(),
     ),
   );
 }

--- a/mobile_frontend/lib/core/di/repositories_init.dart
+++ b/mobile_frontend/lib/core/di/repositories_init.dart
@@ -17,6 +17,9 @@ import '../../features/profile/domain/usecase/totp/confirm_totp.dart';
 import '../../features/profile/domain/usecase/totp/disable_totp.dart';
 import '../../features/profile/domain/repository/totp_repository.dart';
 import '../../features/profile/data/repository/totp_repository_impl.dart';
+import '../../features/budget/domain/repository/budget_repository.dart';
+import '../../features/budget/data/repository/budget_repository_impl.dart';
+import '../../features/budget/domain/usecase/get_transactions_by_date.dart';
 import '../navigation/app_pages.dart';
 import '../navigation/navigation_service.dart';
 import '../network/api_client.dart';
@@ -107,5 +110,13 @@ Future<void> repositoriesInit() async {
 
   getItInstance.registerLazySingleton<DisableTotp>(
     () => DisableTotp(getItInstance<TotpRepository>()),
+  );
+
+  getItInstance.registerLazySingleton<BudgetRepository>(
+    () => BudgetRepositoryImpl(getItInstance<ApiClient>()),
+  );
+
+  getItInstance.registerLazySingleton<GetTransactionsByDate>(
+    () => GetTransactionsByDate(getItInstance<BudgetRepository>()),
   );
 }

--- a/mobile_frontend/lib/core/network/api_client.dart
+++ b/mobile_frontend/lib/core/network/api_client.dart
@@ -13,6 +13,7 @@ import '../../features/profile/data/model/totp_setup_response.dart';
 import '../../features/profile/data/model/totp_status_response.dart';
 import '../../features/profile/data/model/totp_code_request.dart';
 import '../../features/auth/data/model/request/refresh_token_request.dart';
+import '../../features/budget/data/model/transaction.dart';
 import '../constants/app_api.dart';
 import '../constants/app_constants.dart';
 import '../constants/app_routes.dart';
@@ -141,6 +142,9 @@ abstract class ApiClient {
 
   @POST(AppApi.totp_disable)
   Future<void> disableTotp(@Body() TotpCodeRequest request);
+
+  @GET(AppApi.transactions)
+  Future<List<Transaction>> getTransactions(@Query('date') String date);
 
 
 }

--- a/mobile_frontend/lib/core/network/api_client.g.dart
+++ b/mobile_frontend/lib/core/network/api_client.g.dart
@@ -326,6 +326,40 @@ class _ApiClient implements ApiClient {
     await _dio.fetch<void>(_options);
   }
 
+  @override
+  Future<List<Transaction>> getTransactions(String date) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{r'date': date};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    final _options = _setStreamType<List<dynamic>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+        .compose(
+          _dio.options,
+          '/transactions',
+          queryParameters: queryParameters,
+        )
+        .copyWith(
+            baseUrl: _combineBaseUrls(
+          _dio.options.baseUrl,
+          baseUrl,
+        )));
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    List<Transaction> _value;
+    try {
+      _value = _result.data!
+          .map((dynamic i) => Transaction.fromJson(i as Map<String, dynamic>))
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options);
+      rethrow;
+    }
+    return _value;
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/mobile_frontend/lib/features/budget/data/model/transaction.dart
+++ b/mobile_frontend/lib/features/budget/data/model/transaction.dart
@@ -1,13 +1,26 @@
 class Transaction {
+  final String id;
   final String title;
   final double amount;
   final DateTime date;
   final bool isIncome;
 
   Transaction({
+    required this.id,
     required this.title,
     required this.amount,
     required this.date,
     this.isIncome = true,
   });
+
+  factory Transaction.fromJson(Map<String, dynamic> json) {
+    final amt = json['amount'] as num? ?? 0;
+    return Transaction(
+      id: json['id']?.toString() ?? '',
+      title: json['description'] as String? ?? '',
+      amount: amt.toDouble(),
+      date: DateTime.parse(json['created_at'] as String),
+      isIncome: amt >= 0,
+    );
+  }
 }

--- a/mobile_frontend/lib/features/budget/data/repository/budget_repository_impl.dart
+++ b/mobile_frontend/lib/features/budget/data/repository/budget_repository_impl.dart
@@ -1,0 +1,21 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/network/api_client.dart';
+import '../../../../core/network/failure.dart';
+import '../../domain/repository/budget_repository.dart';
+import '../model/transaction.dart';
+
+class BudgetRepositoryImpl with BudgetRepository {
+  final ApiClient _client;
+  BudgetRepositoryImpl(this._client);
+
+  @override
+  Future<Either<Failure, List<Transaction>>> transactionsByDate(DateTime date) async {
+    try {
+      final resp = await _client.getTransactions(date.toIso8601String());
+      return Right(resp);
+    } catch (e) {
+      return Left(Failure(errorMessage: e.toString()));
+    }
+  }
+}

--- a/mobile_frontend/lib/features/budget/domain/repository/budget_repository.dart
+++ b/mobile_frontend/lib/features/budget/domain/repository/budget_repository.dart
@@ -1,0 +1,7 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/network/failure.dart';
+import '../../data/model/transaction.dart';
+
+mixin BudgetRepository {
+  Future<Either<Failure, List<Transaction>>> transactionsByDate(DateTime date);
+}

--- a/mobile_frontend/lib/features/budget/domain/usecase/get_transactions_by_date.dart
+++ b/mobile_frontend/lib/features/budget/domain/usecase/get_transactions_by_date.dart
@@ -1,0 +1,20 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/network/failure.dart';
+import '../../../../core/network/use_case.dart';
+import '../repository/budget_repository.dart';
+import '../../data/model/transaction.dart';
+
+class GetTransactionsByDate extends UseCase<List<Transaction>, GetTransactionsByDateParams> {
+  final BudgetRepository _repository;
+  GetTransactionsByDate(this._repository);
+
+  @override
+  Future<Either<Failure, List<Transaction>>> call(GetTransactionsByDateParams params) {
+    return _repository.transactionsByDate(params.date);
+  }
+}
+
+class GetTransactionsByDateParams {
+  final DateTime date;
+  const GetTransactionsByDateParams(this.date);
+}

--- a/mobile_frontend/lib/features/budget/presentation/cubit/budget_cubit.dart
+++ b/mobile_frontend/lib/features/budget/presentation/cubit/budget_cubit.dart
@@ -1,0 +1,57 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/helpers/enums_helpers.dart';
+import '../../domain/usecase/get_transactions_by_date.dart';
+import '../../data/model/transaction.dart';
+
+class BudgetState extends Equatable {
+  final RequestStatus status;
+  final List<Transaction> transactions;
+  final String errorMessage;
+  final DateTime selectedDate;
+
+  const BudgetState({
+    this.status = RequestStatus.initial,
+    this.transactions = const [],
+    this.errorMessage = '',
+    required this.selectedDate,
+  });
+
+  BudgetState copyWith({
+    RequestStatus? status,
+    List<Transaction>? transactions,
+    String? errorMessage,
+    DateTime? selectedDate,
+  }) {
+    return BudgetState(
+      status: status ?? this.status,
+      transactions: transactions ?? this.transactions,
+      errorMessage: errorMessage ?? this.errorMessage,
+      selectedDate: selectedDate ?? this.selectedDate,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, transactions, errorMessage, selectedDate];
+}
+
+class BudgetCubit extends Cubit<BudgetState> {
+  final GetTransactionsByDate _getTransactions;
+
+  BudgetCubit(this._getTransactions)
+      : super(BudgetState(selectedDate: DateTime.now()));
+
+  Future<void> load(DateTime date) async {
+    emit(state.copyWith(status: RequestStatus.loading, selectedDate: date));
+    final result = await _getTransactions(GetTransactionsByDateParams(date));
+    result.fold(
+      (failure) => emit(
+        state.copyWith(status: RequestStatus.error, errorMessage: failure.errorMessage),
+      ),
+      (data) => emit(
+        state.copyWith(status: RequestStatus.loaded, transactions: data),
+      ),
+    );
+  }
+}

--- a/mobile_frontend/lib/features/budget/presentation/pages/budget_page.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/budget_page.dart
@@ -4,6 +4,8 @@ import 'package:intl/intl.dart';
 
 import '../../../../core/constants/app_colors.dart';
 import '../../data/model/transaction.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../cubit/budget_cubit.dart';
 
 class BudgetPage extends StatefulWidget {
   const BudgetPage({super.key});
@@ -13,20 +15,6 @@ class BudgetPage extends StatefulWidget {
 }
 
 class _BudgetPageState extends State<BudgetPage> {
-  final List<Transaction> _transactions = [
-    Transaction(
-      title: 'Coffee',
-      amount: -3.5,
-      date: DateTime(2025, 7, 20),
-      isIncome: false,
-    ),
-    Transaction(
-      title: 'Salary',
-      amount: 1500,
-      date: DateTime(2025, 7, 19),
-      isIncome: true,
-    ),
-  ];
 
   @override
   Widget build(BuildContext context) {
@@ -100,11 +88,15 @@ class _BudgetPageState extends State<BudgetPage> {
             padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: const [
-                Text('20 July 2025',
-                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+              children: [
+                Text(
+                  DateFormat('dd MMM yyyy').format(
+                    context.watch<BudgetCubit>().state.selectedDate,
+                  ),
+                  style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                ),
                 Row(
-                  children: [
+                  children: const [
                     _BalanceChip(text: '+0 ₽'),
                     SizedBox(width: 8),
                     _BalanceChip(text: '-0 ₽'),
@@ -117,7 +109,7 @@ class _BudgetPageState extends State<BudgetPage> {
           Expanded(
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: _transactions.isEmpty
+              child: context.watch<BudgetCubit>().state.transactions.isEmpty
                   ? Container(
                       width: double.infinity,
                       padding: const EdgeInsets.all(20),
@@ -135,10 +127,10 @@ class _BudgetPageState extends State<BudgetPage> {
                       ),
                     )
                   : ListView.separated(
-                      itemCount: _transactions.length,
+                      itemCount: context.watch<BudgetCubit>().state.transactions.length,
                       separatorBuilder: (_, __) => const Divider(),
                       itemBuilder: (context, index) {
-                        final tx = _transactions[index];
+                        final tx = context.watch<BudgetCubit>().state.transactions[index];
                         return ListTile(
                           title: Text(tx.title),
                           subtitle: Text(

--- a/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
+++ b/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
@@ -8,6 +8,8 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import '../../../profile/presentation/cubit/profile_cubit.dart';
 import '../../../home/presentation/pages/home_page.dart';
 import '../../../budget/presentation/pages/budget_page.dart';
+import '../../../../core/di/get_it.dart';
+import '../../../budget/presentation/cubit/budget_cubit.dart';
 
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/constants/app_sizes.dart';
@@ -65,7 +67,10 @@ class _MainPageState extends State<MainPage> {
                 value: context.read<ProfileCubit>(),
                 child: const HomePage(),
               ),
-              const BudgetPage(),
+              BlocProvider(
+                create: (_) => getItInstance<BudgetCubit>()..load(DateTime.now()),
+                child: const BudgetPage(),
+              ),
             ],
           ),
           bottomNavigationBar: CurvedBottomNavbar(


### PR DESCRIPTION
## Summary
- support transaction queries on backend
- add API client call and repository for transactions
- wire BudgetCubit to fetch transactions
- display loaded transactions on `BudgetPage`

## Testing
- `python -m py_compile app/api/v1/transactions.py app/schemas/transaction.py app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68764e2116288327a04e343677100dd2