### PR TITLE
Add safe area and rounded modal

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -38,8 +38,11 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
           final cubit = context.read<TransactionCubit>();
           return SizedBox(
             height: MediaQuery.of(context).size.height,
-            child: Scaffold(
-              backgroundColor: AppColors.background,
+            child: SafeArea(
+              top: true,
+              bottom: false,
+              child: Scaffold(
+                backgroundColor: AppColors.background,
               appBar: SubpageAppBar(
                 title: 'Add transaction',
                 onBackTap: () => Navigator.of(context).pop(),

--- a/mobile_frontend/lib/features/budget/presentation/pages/budget_page.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/budget_page.dart
@@ -21,8 +21,10 @@ class _BudgetPageState extends State<BudgetPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.background,
-      body: Column(
-        children: [
+      body: SafeArea(
+        bottom: false,
+        child: Column(
+          children: [
           const SizedBox(height: 12),
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -162,11 +164,18 @@ class _BudgetPageState extends State<BudgetPage> {
           ),
         ],
       ),
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
           showModalBottomSheet(
             context: context,
             isScrollControlled: true,
+            useSafeArea: true,
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.vertical(
+                top: Radius.circular(16),
+              ),
+            ),
             builder: (_) => const AddTransactionModal(),
           );
         },


### PR DESCRIPTION
## Summary
- prevent overlap with the system status bar on budget page
- prevent overlap with the system status bar on add-transaction modal
- round the top edges of the add-transaction modal

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68767064ebc08327bdbaae943e0adc11