### PR TITLE
Fix syntax in add_transaction_modal

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -126,14 +126,14 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                             decoration: const InputDecoration(labelText: 'Note'),
                             onChanged: cubit.setNote,
                           ),
-                        ],
                           WButton(
                             onTap: cubit.submit,
                             text: 'Save',
-                            isDisabled: !state.isValid || state.status.isLoading(),
+                            isDisabled: !state.isValid ||
+                                state.status.isLoading(),
                             isLoading: state.status.isLoading(),
-                        ),
-                        ),
+                          ),
+                        ],
                       ),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- correct widget closure logic in `add_transaction_modal.dart`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b4ad966208327bdf09bd2725b0c68