### PR TITLE
Fix AddTransactionModal bottom button

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -126,14 +126,20 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                             decoration: const InputDecoration(labelText: 'Note'),
                             onChanged: cubit.setNote,
                           ),
-                          WButton(
-                            onTap: cubit.submit,
-                            text: 'Save',
-                            isDisabled: !state.isValid ||
-                                state.status.isLoading(),
-                            isLoading: state.status.isLoading(),
-                          ),
                         ],
+                      ),
+                    ),
+                  ),
+                  Padding(
+                    padding: EdgeInsets.all(AppSizes.paddingM.h),
+                    child: SafeArea(
+                      top: false,
+                      child: WButton(
+                        onTap: cubit.submit,
+                        text: 'Save',
+                        isDisabled: !state.isValid ||
+                            state.status.isLoading(),
+                        isLoading: state.status.isLoading(),
                       ),
                     ),
                   ),


### PR DESCRIPTION
## Summary
- refactor AddTransactionModal to keep the Save button fixed at the bottom

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b4d1a1a2c8327a482b11dfcaa8fd5