### PR TITLE
Implement category management UI

### DIFF
--- a/mobile_frontend/lib/core/di/cubits_init.dart
+++ b/mobile_frontend/lib/core/di/cubits_init.dart
@@ -22,7 +22,9 @@ import '../../features/budget/presentation/cubit/transaction_cubit.dart';
 import '../../features/budget/domain/usecase/add_transaction.dart';
 import '../../features/budget/domain/usecase/get_categories.dart';
 import '../../features/budget/domain/usecase/add_account.dart';
+import '../../features/budget/domain/usecase/add_category.dart';
 import '../../features/budget/presentation/cubit/account_cubit.dart';
+import '../../features/budget/presentation/cubit/category_cubit.dart';
 
 Future<void> cubitsInit() async {
   getItInstance.registerFactory<SplashCubit>(
@@ -71,6 +73,11 @@ Future<void> cubitsInit() async {
   getItInstance.registerFactory<AccountCubit>(
     () => AccountCubit(
       getItInstance<AddAccount>(),
+    ),
+  );
+  getItInstance.registerFactory<CategoryCubit>(
+    () => CategoryCubit(
+      getItInstance<AddCategory>(),
     ),
   );
 }

--- a/mobile_frontend/lib/core/di/repositories_init.dart
+++ b/mobile_frontend/lib/core/di/repositories_init.dart
@@ -23,6 +23,7 @@ import '../../features/budget/domain/usecase/get_transactions_by_date.dart';
 import '../../features/budget/domain/usecase/add_transaction.dart';
 import '../../features/budget/domain/usecase/get_categories.dart';
 import '../../features/budget/domain/usecase/add_account.dart';
+import '../../features/budget/domain/usecase/add_category.dart';
 import '../navigation/app_pages.dart';
 import '../navigation/navigation_service.dart';
 import '../network/api_client.dart';
@@ -128,6 +129,9 @@ Future<void> repositoriesInit() async {
   );
   getItInstance.registerLazySingleton<AddAccount>(
     () => AddAccount(getItInstance<BudgetRepository>()),
+  );
+  getItInstance.registerLazySingleton<AddCategory>(
+    () => AddCategory(getItInstance<BudgetRepository>()),
   );
   getItInstance.registerLazySingleton<GetCategories>(
     () => GetCategories(getItInstance<BudgetRepository>()),

--- a/mobile_frontend/lib/features/budget/data/model/create_category_request.dart
+++ b/mobile_frontend/lib/features/budget/data/model/create_category_request.dart
@@ -1,0 +1,11 @@
+class CreateCategoryRequest {
+  final String name;
+  final String type;
+
+  CreateCategoryRequest({required this.name, required this.type});
+
+  Map<String, dynamic> toJson() => {
+        'name': name,
+        'type': type,
+      };
+}

--- a/mobile_frontend/lib/features/budget/data/repository/budget_repository_impl.dart
+++ b/mobile_frontend/lib/features/budget/data/repository/budget_repository_impl.dart
@@ -7,6 +7,7 @@ import '../model/transaction.dart';
 import '../model/create_transaction_request.dart';
 import '../model/create_account_request.dart';
 import '../model/category.dart';
+import '../model/create_category_request.dart';
 
 class BudgetRepositoryImpl with BudgetRepository {
   final ApiClient _client;
@@ -47,6 +48,16 @@ class BudgetRepositoryImpl with BudgetRepository {
     try {
       final resp = await _client.getCategories(type);
       return Right(resp.map((e) => Category.fromJson(e)).toList());
+    } catch (e) {
+      return Left(Failure(errorMessage: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> createCategory(CreateCategoryRequest request) async {
+    try {
+      await _client.createCategory(request.toJson());
+      return const Right(null);
     } catch (e) {
       return Left(Failure(errorMessage: e.toString()));
     }

--- a/mobile_frontend/lib/features/budget/domain/repository/budget_repository.dart
+++ b/mobile_frontend/lib/features/budget/domain/repository/budget_repository.dart
@@ -4,10 +4,12 @@ import '../../data/model/transaction.dart';
 import '../../data/model/create_transaction_request.dart';
 import '../../data/model/create_account_request.dart';
 import '../../data/model/category.dart';
+import '../../data/model/create_category_request.dart';
 
 mixin BudgetRepository {
   Future<Either<Failure, List<Transaction>>> transactionsByDate(DateTime date);
   Future<Either<Failure, void>> createTransaction(CreateTransactionRequest request);
   Future<Either<Failure, void>> createAccount(CreateAccountRequest request);
   Future<Either<Failure, List<Category>>> getCategories(String type);
+  Future<Either<Failure, void>> createCategory(CreateCategoryRequest request);
 }

--- a/mobile_frontend/lib/features/budget/domain/usecase/add_category.dart
+++ b/mobile_frontend/lib/features/budget/domain/usecase/add_category.dart
@@ -1,0 +1,21 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/network/failure.dart';
+import '../../../../core/network/use_case.dart';
+import '../repository/budget_repository.dart';
+import '../../data/model/create_category_request.dart';
+
+class AddCategory extends UseCase<void, AddCategoryParams> {
+  final BudgetRepository _repository;
+  AddCategory(this._repository);
+
+  @override
+  Future<Either<Failure, void>> call(AddCategoryParams params) {
+    return _repository.createCategory(params.request);
+  }
+}
+
+class AddCategoryParams {
+  final CreateCategoryRequest request;
+  AddCategoryParams(this.request);
+}

--- a/mobile_frontend/lib/features/budget/presentation/cubit/category_cubit.dart
+++ b/mobile_frontend/lib/features/budget/presentation/cubit/category_cubit.dart
@@ -1,0 +1,54 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../../core/helpers/enums_helpers.dart';
+import '../../domain/usecase/add_category.dart';
+import '../../data/model/create_category_request.dart';
+import 'transaction_cubit.dart';
+
+class CategoryState extends Equatable {
+  final String name;
+  final TransactionType type;
+  final RequestStatus status;
+  final String errorMessage;
+
+  const CategoryState({
+    this.name = '',
+    this.type = TransactionType.income,
+    this.status = RequestStatus.initial,
+    this.errorMessage = '',
+  });
+
+  CategoryState copyWith({
+    String? name,
+    TransactionType? type,
+    RequestStatus? status,
+    String? errorMessage,
+  }) => CategoryState(
+        name: name ?? this.name,
+        type: type ?? this.type,
+        status: status ?? this.status,
+        errorMessage: errorMessage ?? this.errorMessage,
+      );
+
+  @override
+  List<Object?> get props => [name, type, status, errorMessage];
+}
+
+class CategoryCubit extends Cubit<CategoryState> {
+  final AddCategory _addCategory;
+  CategoryCubit(this._addCategory) : super(const CategoryState());
+
+  void setName(String v) => emit(state.copyWith(name: v));
+  void setType(TransactionType t) => emit(state.copyWith(type: t));
+
+  Future<void> submit() async {
+    emit(state.copyWith(status: RequestStatus.loading));
+    final request = CreateCategoryRequest(name: state.name, type: state.type.name);
+    final result = await _addCategory(AddCategoryParams(request));
+    result.fold(
+      (l) => emit(state.copyWith(status: RequestStatus.error, errorMessage: l.errorMessage)),
+      (_) => emit(state.copyWith(status: RequestStatus.loaded)),
+    );
+  }
+}

--- a/mobile_frontend/lib/features/budget/presentation/pages/add_category_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_category_modal.dart
@@ -1,37 +1,38 @@
 import 'package:Finance/core/constants/app_colors.dart';
 import 'package:Finance/core/constants/app_sizes.dart';
+import 'package:Finance/core/di/get_it.dart';
+import 'package:Finance/core/themes/app_text_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:Finance/core/di/get_it.dart';
-import '../cubit/account_cubit.dart';
+
+import '../cubit/category_cubit.dart';
+import '../cubit/transaction_cubit.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
 
-class AddAccountModal extends StatefulWidget {
-  const AddAccountModal({super.key});
+class AddCategoryModal extends StatefulWidget {
+  const AddCategoryModal({super.key});
 
   @override
-  State<AddAccountModal> createState() => _AddAccountModalState();
+  State<AddCategoryModal> createState() => _AddCategoryModalState();
 }
 
-class _AddAccountModalState extends State<AddAccountModal> {
+class _AddCategoryModalState extends State<AddCategoryModal> {
   final _nameController = TextEditingController();
-  final _balanceController = TextEditingController();
 
   @override
   void dispose() {
     _nameController.dispose();
-    _balanceController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => getItInstance<AccountCubit>(),
-      child: BlocBuilder<AccountCubit, AccountState>(
+      create: (_) => getItInstance<CategoryCubit>(),
+      child: BlocBuilder<CategoryCubit, CategoryState>(
         builder: (context, state) {
-          final cubit = context.read<AccountCubit>();
+          final cubit = context.read<CategoryCubit>();
           return Container(
             height: MediaQuery.of(context).size.height,
             child: SafeArea(
@@ -59,17 +60,18 @@ class _AddAccountModalState extends State<AddAccountModal> {
                             padding: EdgeInsets.all(AppSizes.paddingM.h),
                             child: Column(
                               children: [
+                                Row(
+                                  children: [
+                                    _typeButton(context, cubit, TransactionType.income, 'Income'),
+                                    SizedBox(width: AppSizes.spaceXS8.w),
+                                    _typeButton(context, cubit, TransactionType.purchase, 'Purchase'),
+                                  ],
+                                ),
+                                SizedBox(height: AppSizes.spaceM16.h),
                                 TextField(
                                   controller: _nameController,
                                   decoration: const InputDecoration(labelText: 'Name'),
                                   onChanged: cubit.setName,
-                                ),
-                                SizedBox(height: AppSizes.spaceM16.h),
-                                TextField(
-                                  controller: _balanceController,
-                                  decoration: const InputDecoration(labelText: 'Initial balance'),
-                                  keyboardType: TextInputType.number,
-                                  onChanged: (v) => cubit.setBalance(int.tryParse(v) ?? 0),
                                 ),
                               ],
                             ),
@@ -95,6 +97,34 @@ class _AddAccountModalState extends State<AddAccountModal> {
             ),
           );
         },
+      ),
+    );
+  }
+
+  Widget _typeButton(BuildContext context, CategoryCubit cubit, TransactionType type, String label) {
+    final selected = cubit.state.type == type;
+    return GestureDetector(
+      onTap: () => cubit.setType(type),
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: AppSizes.paddingS, horizontal: AppSizes.paddingM),
+        decoration: BoxDecoration(
+          color: selected ? AppColors.primary : AppColors.secondary,
+          border: const Border(
+            bottom: BorderSide(color: AppColors.def, width: 0.5),
+          ),
+          borderRadius: BorderRadius.circular(AppSizes.borderMedium),
+          boxShadow: [
+            BoxShadow(
+              color: !selected ? AppColors.transparent : AppColors.primary,
+              blurRadius: !selected ? 0 : 5,
+              spreadRadius: !selected ? 0.1 : 0,
+              blurStyle: BlurStyle.outer,
+              offset: const Offset(0, 0),
+            )
+          ],
+        ),
+        alignment: Alignment.center,
+        child: Text(label, style: AppTextStyles.bodyRegular),
       ),
     );
   }

--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -10,6 +10,7 @@ import 'package:intl/intl.dart';
 import '../cubit/transaction_cubit.dart';
 import '../../data/model/category.dart';
 import '../../../shared/presentation/widgets/app_buttons/w_button.dart';
+import 'add_category_modal.dart';
 
 class AddTransactionModal extends StatefulWidget {
   const AddTransactionModal({super.key});
@@ -143,12 +144,16 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                           child: Container(
                             width: double.maxFinite,
                             padding: EdgeInsets.all(AppSizes.paddingM.h),
-                            child: Wrap(
-                              spacing: AppSizes.spaceXS8.w,
-                              runSpacing: AppSizes.spaceXS8.w,
-                              children: state.categories
-                                  .map((e) => _categoryItem(context, cubit, e))
-                                  .toList(),
+                            child: GridView.count(
+                              crossAxisCount: 3,
+                              crossAxisSpacing: AppSizes.spaceXS8.w,
+                              mainAxisSpacing: AppSizes.spaceXS8.w,
+                              children: [
+                                ...state.categories
+                                    .map((e) => _categoryItem(context, cubit, e))
+                                    .toList(),
+                                _addCategoryButton(context, cubit),
+                              ],
                             ),
                           ),
                         ),
@@ -234,6 +239,35 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
         ),
         alignment: Alignment.center,
         child: Text(cat.name, style: AppTextStyles.bodyRegular),
+      ),
+    );
+  }
+
+  Widget _addCategoryButton(BuildContext context, TransactionCubit cubit) {
+    return GestureDetector(
+      onTap: () async {
+        await showModalBottomSheet(
+          context: context,
+          isScrollControlled: true,
+          useSafeArea: true,
+          shape: const RoundedRectangleBorder(
+            borderRadius: BorderRadius.vertical(top: Radius.circular(AppSizes.borderSM16)),
+          ),
+          builder: (_) => const AddCategoryModal(),
+        );
+        cubit.loadCategories();
+      },
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: AppSizes.paddingS, horizontal: AppSizes.paddingM),
+        decoration: BoxDecoration(
+          color: AppColors.secondary,
+          border: const Border(
+            bottom: BorderSide(color: AppColors.def, width: 0.5),
+          ),
+          borderRadius: BorderRadius.circular(AppSizes.borderMedium),
+        ),
+        alignment: Alignment.center,
+        child: const Icon(Icons.add),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add model & usecase for creating category
- expose repository methods and cubits for category creation
- style AddAccount modal to match AddTransaction modal
- implement AddCategoryModal and integrate with transaction modal
- display categories in a 3-column grid with an add-category button

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b66356dac8327b0d9df041881b095