### PR TITLE
Fix add category and account endpoints

### DIFF
--- a/app/api/v1/accounts.py
+++ b/app/api/v1/accounts.py
@@ -3,12 +3,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
 from database import get_session
-from models.accounts import Account
+from models.accounts import Account, AccountType
 from models.users import User
 import services.auth_service as auth_service
 from schemas.account import AccountRead, AccountCreate
 
 router = APIRouter(prefix="/accounts", tags=["Accounts"])
+
 
 @router.get("", response_model=list[AccountRead])
 async def list_accounts(
@@ -17,6 +18,7 @@ async def list_accounts(
 ):
     result = await session.scalars(select(Account).where(Account.user_id == user.id))
     return list(result)
+
 
 @router.post("", response_model=AccountRead, status_code=201)
 async def create_account(
@@ -28,7 +30,9 @@ async def create_account(
         user_id=user.id,
         account_name=data.account_name,
         account_number=data.account_number,
-        account_type=data.account_type,
+        account_type=(
+            AccountType(data.account_type) if data.account_type is not None else None
+        ),
         balance=data.initial_balance,
         initial_balance=data.initial_balance,
     )

--- a/app/api/v1/categories.py
+++ b/app/api/v1/categories.py
@@ -3,12 +3,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
 from database import get_session
-from models.categories import Category
+from models.categories import Category, CategoryType
 from models.users import User
 import services.auth_service as auth_service
 from schemas.category import CategoryCreate, CategoryRead
 
 router = APIRouter(prefix="/categories", tags=["Categories"])
+
 
 @router.get("", response_model=list[CategoryRead])
 async def list_categories(
@@ -18,9 +19,14 @@ async def list_categories(
 ):
     stmt = select(Category).where(Category.user_id == user.id)
     if type:
-        stmt = stmt.where(Category.type == type)
+        try:
+            cat_type = CategoryType(type)
+        except ValueError:
+            return []
+        stmt = stmt.where(Category.type == cat_type)
     result = await session.scalars(stmt)
     return list(result)
+
 
 @router.post("", response_model=CategoryRead, status_code=201)
 async def create_category(
@@ -28,7 +34,11 @@ async def create_category(
     user: User = Depends(auth_service.get_current_user),
     session: AsyncSession = Depends(get_session),
 ):
-    cat = Category(user_id=user.id, name=data.name, type=data.type)
+    cat = Category(
+        user_id=user.id,
+        name=data.name,
+        type=CategoryType(data.type),
+    )
     session.add(cat)
     await session.commit()
     await session.refresh(cat)


### PR DESCRIPTION
## Summary
- fix API endpoints for account and category creation by using Enum types
- handle query filtering by converting string types to enums

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b6a763860832785dc2aa2b1446d29