### PR TITLE
Fix CategoryType handling in category API

### DIFF
--- a/app/api/v1/categories.py
+++ b/app/api/v1/categories.py
@@ -13,17 +13,13 @@ router = APIRouter(prefix="/categories", tags=["Categories"])
 
 @router.get("", response_model=list[CategoryRead])
 async def list_categories(
-    type: str | None = None,
+    type: CategoryType | None = None,
     user: User = Depends(auth_service.get_current_user),
     session: AsyncSession = Depends(get_session),
 ):
     stmt = select(Category).where(Category.user_id == user.id)
     if type:
-        try:
-            cat_type = CategoryType(type)
-        except ValueError:
-            return []
-        stmt = stmt.where(Category.type == cat_type)
+        stmt = stmt.where(Category.type == type)
     result = await session.scalars(stmt)
     return list(result)
 
@@ -37,7 +33,7 @@ async def create_category(
     cat = Category(
         user_id=user.id,
         name=data.name,
-        type=CategoryType(data.type),
+        type=data.type,
     )
     session.add(cat)
     await session.commit()

--- a/app/schemas/category.py
+++ b/app/schemas/category.py
@@ -1,15 +1,16 @@
 import uuid
 from datetime import datetime
 from pydantic import BaseModel
+from models.categories import CategoryType
 
 class CategoryCreate(BaseModel):
     name: str
-    type: str
+    type: CategoryType
 
 class CategoryRead(BaseModel):
     id: uuid.UUID
     name: str
-    type: str
+    type: CategoryType
     created_at: datetime
 
     model_config = {"from_attributes": True}


### PR DESCRIPTION
## Summary
- parse CategoryType using Pydantic instead of manual conversion
- update schemas to use CategoryType directly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687b72eaf90c8327b3ba0d1c3e8d66fa