### PR TITLE
Add categories migration and improve category modal

### DIFF
--- a/app/alembic/versions/20240720_add_categories.py
+++ b/app/alembic/versions/20240720_add_categories.py
@@ -1,0 +1,40 @@
+"""add categories table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '20240720_add_categories'
+down_revision = '20240713_add_profile_fields'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'categories',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('name', sa.String(length=50), nullable=False),
+        sa.Column(
+            'type',
+            sa.Enum('INCOME', 'PURCHASE', name='categorytype'),
+            nullable=False,
+        ),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column(
+            'updated_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.text('now()'),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.add_column('transactions', sa.Column('category_id', sa.UUID(), nullable=True))
+    op.create_foreign_key(None, 'transactions', 'categories', ['category_id'], ['id'], ondelete='SET NULL')
+
+
+def downgrade() -> None:
+    op.drop_constraint(None, 'transactions', type_='foreignkey')
+    op.drop_column('transactions', 'category_id')
+    op.drop_table('categories')

--- a/mobile_frontend/lib/features/budget/presentation/pages/add_category_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_category_modal.dart
@@ -30,7 +30,12 @@ class _AddCategoryModalState extends State<AddCategoryModal> {
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (_) => getItInstance<CategoryCubit>(),
-      child: BlocBuilder<CategoryCubit, CategoryState>(
+      child: BlocConsumer<CategoryCubit, CategoryState>(
+        listener: (context, state) {
+          if (state.status.isLoaded()) {
+            Navigator.of(context).pop();
+          }
+        },
         builder: (context, state) {
           final cubit = context.read<CategoryCubit>();
           return Container(


### PR DESCRIPTION
## Summary
- create Alembic migration for categories table with relation to transactions
- close Add Category modal after a successful save

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b77819dfc8327a2de1856ce8a9685