### PR TITLE
Add query token support

### DIFF
--- a/app/api/v1/accounts.py
+++ b/app/api/v1/accounts.py
@@ -13,7 +13,7 @@ router = APIRouter(prefix="/accounts", tags=["Accounts"])
 
 @router.get("", response_model=list[AccountRead])
 async def list_accounts(
-    user: User = Depends(auth_service.get_current_user),
+    user: User = Depends(auth_service.get_current_user_with_access),
     session: AsyncSession = Depends(get_session),
 ):
     result = await session.scalars(select(Account).where(Account.user_id == user.id))
@@ -23,7 +23,7 @@ async def list_accounts(
 @router.post("", response_model=AccountRead, status_code=201)
 async def create_account(
     data: AccountCreate,
-    user: User = Depends(auth_service.get_current_user),
+    user: User = Depends(auth_service.get_current_user_with_access),
     session: AsyncSession = Depends(get_session),
 ):
     acc = Account(

--- a/app/api/v1/categories.py
+++ b/app/api/v1/categories.py
@@ -14,7 +14,7 @@ router = APIRouter(prefix="/categories", tags=["Categories"])
 @router.get("", response_model=list[CategoryRead])
 async def list_categories(
     type: CategoryType | None = None,
-    user: User = Depends(auth_service.get_current_user),
+    user: User = Depends(auth_service.get_current_user_with_access),
     session: AsyncSession = Depends(get_session),
 ):
     stmt = select(Category).where(Category.user_id == user.id)
@@ -27,7 +27,7 @@ async def list_categories(
 @router.post("", response_model=CategoryRead, status_code=201)
 async def create_category(
     data: CategoryCreate,
-    user: User = Depends(auth_service.get_current_user),
+    user: User = Depends(auth_service.get_current_user_with_access),
     session: AsyncSession = Depends(get_session),
 ):
     cat = Category(

--- a/app/api/v1/transactions.py
+++ b/app/api/v1/transactions.py
@@ -14,7 +14,7 @@ router = APIRouter(prefix="/transactions", tags=["Transactions"])
 @router.get("", response_model=list[TransactionRead])
 async def transactions_by_date(
     date: date,
-    user: User = Depends(auth_service.get_current_user),
+    user: User = Depends(auth_service.get_current_user_with_access),
     session: AsyncSession = Depends(get_session),
 ):
     start = datetime.combine(date, datetime.min.time())
@@ -31,7 +31,7 @@ async def transactions_by_date(
 @router.post("", response_model=TransactionRead, status_code=201)
 async def create_transaction(
     data: TransactionCreate,
-    user: User = Depends(auth_service.get_current_user),
+    user: User = Depends(auth_service.get_current_user_with_access),
     session: AsyncSession = Depends(get_session),
 ):
     amount = int(data.amount)


### PR DESCRIPTION
## Summary
- enable reading access_token query param
- update accounts, categories and transactions routes to use new access-token dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687b7f37d8d48327adaf69db0431d365