### PR TITLE
Fix TransactionCubit provider

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -1,7 +1,6 @@
 import 'package:Finance/core/constants/app_colors.dart';
 import 'package:Finance/core/constants/app_sizes.dart';
 import 'package:Finance/core/themes/app_text_styles.dart';
-import 'package:Finance/core/di/get_it.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -24,15 +23,6 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
   final _noteController = TextEditingController();
 
   @override
-  void initState() {
-    super.initState();
-    // Load categories after widget build
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      context.read<TransactionCubit>().loadCategories();
-    });
-  }
-
-  @override
   void dispose() {
     _amountController.dispose();
     _noteController.dispose();
@@ -41,12 +31,10 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (_) => getItInstance<TransactionCubit>(),
-      child: BlocBuilder<TransactionCubit, TransactionState>(
-        builder: (context, state) {
-          final cubit = context.read<TransactionCubit>();
-          return Container(
+    return BlocBuilder<TransactionCubit, TransactionState>(
+      builder: (context, state) {
+        final cubit = context.read<TransactionCubit>();
+        return Container(
             height: MediaQuery.of(context).size.height,
             child: SafeArea(
               top: true,

--- a/mobile_frontend/lib/features/budget/presentation/pages/budget_page.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/budget_page.dart
@@ -8,6 +8,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import '../cubit/budget_cubit.dart';
 import 'add_transaction_modal.dart';
 import 'add_account_modal.dart';
+import '../cubit/transaction_cubit.dart';
+import '../../../../core/di/get_it.dart';
 
 class BudgetPage extends StatefulWidget {
   const BudgetPage({super.key});
@@ -174,7 +176,10 @@ class _BudgetPageState extends State<BudgetPage> {
                 top: Radius.circular(16),
               ),
             ),
-            builder: (_) => const AddTransactionModal(),
+            builder: (_) => BlocProvider(
+              create: (_) => getItInstance<TransactionCubit>()..loadCategories(),
+              child: const AddTransactionModal(),
+            ),
           );
         },
         backgroundColor: Colors.blue,


### PR DESCRIPTION
## Summary
- ensure `AddTransactionModal` uses existing TransactionCubit
- provide cubit and load categories when opening the transaction modal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b95d8eea083278c16444839cc60f9