### PR TITLE
Handle integer category types in Flutter model

### DIFF
--- a/mobile_frontend/lib/core/helpers/enums_helpers.dart
+++ b/mobile_frontend/lib/core/helpers/enums_helpers.dart
@@ -22,7 +22,7 @@ enum RequestStatus {
   bool isLoadingMore() => this == RequestStatus.loadingMore;
 }
 
-enum CategoryType { income, purchase }
+enum CategoryType { income, purchase, transfer }
 
 extension CategoryTypeX on CategoryType {
   static CategoryType fromString(String value) {
@@ -30,5 +30,18 @@ extension CategoryTypeX on CategoryType {
       (e) => e.name.toLowerCase() == value.toLowerCase(),
       orElse: () => CategoryType.income,
     );
+  }
+
+  static CategoryType fromValue(int? value) {
+    switch (value) {
+      case 1:
+        return CategoryType.income;
+      case -1:
+        return CategoryType.purchase;
+      case 2:
+        return CategoryType.transfer;
+      default:
+        return CategoryType.income;
+    }
   }
 }

--- a/mobile_frontend/lib/features/budget/data/model/category.dart
+++ b/mobile_frontend/lib/features/budget/data/model/category.dart
@@ -7,9 +7,18 @@ class Category {
 
   Category({required this.id, required this.name, required this.type});
 
-  factory Category.fromJson(Map<String, dynamic> json) => Category(
-        id: json['id']?.toString() ?? '',
-        name: json['name'] as String? ?? '',
-        type: CategoryTypeX.fromString(json['type'] as String? ?? ''),
-      );
+  factory Category.fromJson(Map<String, dynamic> json) {
+    final dynamic rawType = json['type'];
+    int? intType;
+    if (rawType is int) {
+      intType = rawType;
+    } else if (rawType is String) {
+      intType = int.tryParse(rawType);
+    }
+    return Category(
+      id: json['id']?.toString() ?? '',
+      name: json['name'] as String? ?? '',
+      type: CategoryTypeX.fromValue(intType),
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- support new category enum type value `transfer`
- parse category type int values safely

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9c0edbc08327b1737189fe63ab20