### PR TITLE
Fix category type parsing

### DIFF
--- a/app/models/categories.py
+++ b/app/models/categories.py
@@ -10,11 +10,24 @@ class CategoryType(Enum):
 
     @classmethod
     def _missing_(cls, value):
-        """Support case-insensitive conversion from strings."""
+        """Support case-insensitive conversion from strings or numeric values."""
         if isinstance(value, str):
+            # try to parse numeric value first
+            try:
+                value_int = int(value)
+                for member in cls:
+                    if member.value == value_int:
+                        return member
+            except ValueError:
+                pass
+
             value_lower = value.lower()
             for member in cls:
-                if member.value.lower() == value_lower or member.name.lower() == value_lower:
+                if member.name.lower() == value_lower:
+                    return member
+        elif isinstance(value, int):
+            for member in cls:
+                if member.value == value:
                     return member
         return None
 

--- a/mobile_frontend/lib/features/budget/data/model/category.dart
+++ b/mobile_frontend/lib/features/budget/data/model/category.dart
@@ -9,16 +9,25 @@ class Category {
 
   factory Category.fromJson(Map<String, dynamic> json) {
     final dynamic rawType = json['type'];
-    int? intType;
+
+    CategoryType type;
     if (rawType is int) {
-      intType = rawType;
+      type = CategoryTypeX.fromValue(rawType);
     } else if (rawType is String) {
-      intType = int.tryParse(rawType);
+      final parsed = int.tryParse(rawType);
+      if (parsed != null) {
+        type = CategoryTypeX.fromValue(parsed);
+      } else {
+        type = CategoryTypeX.fromString(rawType);
+      }
+    } else {
+      type = CategoryType.income;
     }
+
     return Category(
       id: json['id']?.toString() ?? '',
       name: json['name'] as String? ?? '',
-      type: CategoryTypeX.fromValue(intType),
+      type: type,
     );
   }
 }


### PR DESCRIPTION
## Summary
- fix category type parsing for backend `CategoryType` to accept numeric or string values
- extend Flutter Category model parsing to handle string or numeric type values

## Testing
- `python -m py_compile app/models/categories.py`

------
https://chatgpt.com/codex/tasks/task_e_687bc67545d08327861c15d9cac070df