### PR TITLE
Implement backend accounts retrieval

### DIFF
--- a/mobile_frontend/lib/core/di/cubits_init.dart
+++ b/mobile_frontend/lib/core/di/cubits_init.dart
@@ -22,6 +22,7 @@ import '../../features/budget/presentation/cubit/transaction_cubit.dart';
 import '../../features/budget/domain/usecase/add_transaction.dart';
 import '../../features/budget/domain/usecase/get_categories.dart';
 import '../../features/budget/domain/usecase/add_account.dart';
+import '../../features/budget/domain/usecase/get_accounts.dart';
 import '../../features/budget/domain/usecase/add_category.dart';
 import '../../features/budget/presentation/cubit/account_cubit.dart';
 import '../../features/budget/presentation/cubit/category_cubit.dart';
@@ -68,6 +69,7 @@ Future<void> cubitsInit() async {
     () => TransactionCubit(
       getItInstance<AddTransaction>(),
       getItInstance<GetCategories>(),
+      getItInstance<GetAccounts>(),
     ),
   );
   getItInstance.registerFactory<AccountCubit>(

--- a/mobile_frontend/lib/core/di/repositories_init.dart
+++ b/mobile_frontend/lib/core/di/repositories_init.dart
@@ -23,6 +23,7 @@ import '../../features/budget/domain/usecase/get_transactions_by_date.dart';
 import '../../features/budget/domain/usecase/add_transaction.dart';
 import '../../features/budget/domain/usecase/get_categories.dart';
 import '../../features/budget/domain/usecase/add_account.dart';
+import '../../features/budget/domain/usecase/get_accounts.dart';
 import '../../features/budget/domain/usecase/add_category.dart';
 import '../navigation/app_pages.dart';
 import '../navigation/navigation_service.dart';
@@ -129,6 +130,9 @@ Future<void> repositoriesInit() async {
   );
   getItInstance.registerLazySingleton<AddAccount>(
     () => AddAccount(getItInstance<BudgetRepository>()),
+  );
+  getItInstance.registerLazySingleton<GetAccounts>(
+    () => GetAccounts(getItInstance<BudgetRepository>()),
   );
   getItInstance.registerLazySingleton<AddCategory>(
     () => AddCategory(getItInstance<BudgetRepository>()),

--- a/mobile_frontend/lib/core/network/api_client.dart
+++ b/mobile_frontend/lib/core/network/api_client.dart
@@ -14,6 +14,7 @@ import '../../features/profile/data/model/totp_status_response.dart';
 import '../../features/profile/data/model/totp_code_request.dart';
 import '../../features/auth/data/model/request/refresh_token_request.dart';
 import '../../features/budget/data/model/transaction.dart';
+import '../../features/budget/data/model/account.dart';
 import '../constants/app_api.dart';
 import '../constants/app_constants.dart';
 import '../constants/app_routes.dart';
@@ -150,7 +151,7 @@ abstract class ApiClient {
   Future<void> createTransaction(@Body() Map<String, dynamic> data);
 
   @GET(AppApi.accounts)
-  Future<List<dynamic>> getAccounts();
+  Future<List<Account>> getAccounts();
 
   @POST(AppApi.accounts)
   Future<void> createAccount(@Body() Map<String, dynamic> data);

--- a/mobile_frontend/lib/core/network/api_client.g.dart
+++ b/mobile_frontend/lib/core/network/api_client.g.dart
@@ -386,7 +386,7 @@ class _ApiClient implements ApiClient {
   }
 
   @override
-  Future<List<dynamic>> getAccounts() async {
+  Future<List<Account>> getAccounts() async {
     final _extra = <String, dynamic>{};
     final queryParameters = <String, dynamic>{};
     final _headers = <String, dynamic>{};
@@ -408,7 +408,11 @@ class _ApiClient implements ApiClient {
           baseUrl,
         )));
     final _result = await _dio.fetch<List<dynamic>>(_options);
-    return _result.data!;
+    List<Account> _value;
+    _value = _result.data!
+        .map((dynamic i) => Account.fromJson(i as Map<String, dynamic>))
+        .toList();
+    return _value;
   }
 
   @override

--- a/mobile_frontend/lib/features/budget/data/model/account.dart
+++ b/mobile_frontend/lib/features/budget/data/model/account.dart
@@ -1,0 +1,27 @@
+class Account {
+  final String id;
+  final String? name;
+  final String? number;
+  final int? type;
+  final int balance;
+
+  Account({
+    required this.id,
+    this.name,
+    this.number,
+    this.type,
+    required this.balance,
+  });
+
+  factory Account.fromJson(Map<String, dynamic> json) {
+    return Account(
+      id: json['id']?.toString() ?? '',
+      name: json['account_name'] as String?,
+      number: json['account_number'] as String?,
+      type: json['account_type'] is int
+          ? json['account_type'] as int
+          : int.tryParse(json['account_type']?.toString() ?? ''),
+      balance: (json['balance'] as num? ?? 0).toInt(),
+    );
+  }
+}

--- a/mobile_frontend/lib/features/budget/data/repository/budget_repository_impl.dart
+++ b/mobile_frontend/lib/features/budget/data/repository/budget_repository_impl.dart
@@ -8,6 +8,7 @@ import '../../domain/repository/budget_repository.dart';
 import '../model/transaction.dart';
 import '../model/create_transaction_request.dart';
 import '../model/create_account_request.dart';
+import '../model/account.dart';
 import '../model/category.dart';
 import '../model/create_category_request.dart';
 
@@ -41,6 +42,16 @@ class BudgetRepositoryImpl with BudgetRepository {
     try {
       await _client.createAccount(request.toJson());
       return const Right(null);
+    } catch (e) {
+      return Left(Failure(errorMessage: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<Account>>> getAccounts() async {
+    try {
+      final resp = await _client.getAccounts();
+      return Right(resp.map((e) => Account.fromJson(e)).toList());
     } catch (e) {
       return Left(Failure(errorMessage: e.toString()));
     }

--- a/mobile_frontend/lib/features/budget/domain/repository/budget_repository.dart
+++ b/mobile_frontend/lib/features/budget/domain/repository/budget_repository.dart
@@ -3,6 +3,7 @@ import '../../../../core/network/failure.dart';
 import '../../data/model/transaction.dart';
 import '../../data/model/create_transaction_request.dart';
 import '../../data/model/create_account_request.dart';
+import '../../data/model/account.dart';
 import '../../data/model/category.dart';
 import '../../data/model/create_category_request.dart';
 
@@ -10,6 +11,7 @@ mixin BudgetRepository {
   Future<Either<Failure, List<Transaction>>> transactionsByDate(DateTime date);
   Future<Either<Failure, void>> createTransaction(CreateTransactionRequest request);
   Future<Either<Failure, void>> createAccount(CreateAccountRequest request);
+  Future<Either<Failure, List<Account>>> getAccounts();
   Future<Either<Failure, List<Category>>> getCategories(String type);
   Future<Either<Failure, void>> createCategory(CreateCategoryRequest request);
 }

--- a/mobile_frontend/lib/features/budget/domain/usecase/get_accounts.dart
+++ b/mobile_frontend/lib/features/budget/domain/usecase/get_accounts.dart
@@ -1,0 +1,16 @@
+import 'package:dartz/dartz.dart';
+
+import '../../../../core/network/failure.dart';
+import '../../../../core/network/use_case.dart';
+import '../repository/budget_repository.dart';
+import '../../data/model/account.dart';
+
+class GetAccounts extends UseCase<List<Account>, NoParams> {
+  final BudgetRepository _repository;
+  GetAccounts(this._repository);
+
+  @override
+  Future<Either<Failure, List<Account>>> call(NoParams params) {
+    return _repository.getAccounts();
+  }
+}

--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -74,15 +74,19 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                                   elevation: 0,
                                   dropdownColor: AppColors.primary,
                                   focusColor: AppColors.secondary,
-                                  borderRadius: const BorderRadius.only(bottomRight: Radius.circular(AppSizes.borderSM16), bottomLeft: Radius.circular(AppSizes.borderSM16)),
+                                  borderRadius: const BorderRadius.only(
+                                      bottomRight: Radius.circular(AppSizes.borderSM16),
+                                      bottomLeft: Radius.circular(AppSizes.borderSM16)),
                                   value: state.accountId.isNotEmpty ? state.accountId : null,
                                   onChanged: (val) => cubit.setAccountId(val ?? ''),
-                                  items: const [
-                                    DropdownMenuItem(value: '1', child: Text('Main')),
-                                    DropdownMenuItem(value: '2', child: Text('Savings')),
-                                    DropdownMenuItem(value: '3', child: Text('Cash')),
-                                    DropdownMenuItem(value: '4', child: Text('Visa')),
-                                  ],
+                                  items: state.accounts
+                                      .map(
+                                        (a) => DropdownMenuItem(
+                                          value: a.id,
+                                          child: Text(a.name ?? 'Account'),
+                                        ),
+                                      )
+                                      .toList(),
                                 ),
                                 Row(
                                   children: [

--- a/mobile_frontend/lib/features/budget/presentation/pages/budget_page.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/budget_page.dart
@@ -177,7 +177,9 @@ class _BudgetPageState extends State<BudgetPage> {
               ),
             ),
             builder: (_) => BlocProvider(
-              create: (_) => getItInstance<TransactionCubit>()..loadCategories(),
+              create: (_) => getItInstance<TransactionCubit>()
+                ..loadAccounts()
+                ..loadCategories(),
               child: const AddTransactionModal(),
             ),
           );


### PR DESCRIPTION
## Summary
- add `Account` model
- implement repository and use case for fetching accounts
- wire `GetAccounts` through DI
- extend `TransactionCubit` with account loading
- load accounts when adding transactions
- show fetched accounts in transaction form
- update Retrofit client for accounts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bd8123e1c8327b1aaecc8b9c5aba9