### PR TITLE
Fix imports in budget and profile cubits

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/cubit/transaction_cubit.dart
+++ b/mobile_frontend/lib/features/budget/presentation/cubit/transaction_cubit.dart
@@ -8,6 +8,7 @@ import '../../domain/usecase/get_categories.dart';
 import '../../domain/usecase/get_accounts.dart';
 import '../../data/model/category.dart';
 import '../../data/model/account.dart';
+import '../../../../core/network/no_params.dart';
 
 enum TransactionType { income, purchase, transfer }
 

--- a/mobile_frontend/lib/features/profile/presentation/cubit/totp_cubit.dart
+++ b/mobile_frontend/lib/features/profile/presentation/cubit/totp_cubit.dart
@@ -2,10 +2,6 @@ import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 
 import '../../../../core/helpers/enums_helpers.dart';
-import '../../domain/usecase/totp/get_totp_status.dart';
-import '../../domain/usecase/totp/enable_totp.dart';
-import '../../domain/usecase/totp/confirm_totp.dart';
-import '../../domain/usecase/totp/disable_totp.dart';
 import '../../domain/usecase/totp/confirm_totp.dart' as c;
 import '../../domain/usecase/totp/disable_totp.dart' as d;
 import '../../domain/usecase/totp/get_totp_status.dart' as s;


### PR DESCRIPTION
## Summary
- add missing `NoParams` import for TransactionCubit
- clean duplicate imports in TotpCubit

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c7575a148832795e55d8c01ca0dc6