### PR TITLE
Fix migration enums

### DIFF
--- a/app/alembic/versions/bd3f600cbc1e_update_accounts_schema.py
+++ b/app/alembic/versions/bd3f600cbc1e_update_accounts_schema.py
@@ -33,16 +33,30 @@ def upgrade() -> None:
     op.alter_column('accounts', 'name', new_column_name='account_name')
 
     # change column types
-    op.alter_column('accounts', 'account_type',
-                    existing_type=sa.String(length=20),
-                    type_=account_type_enum,
-                    existing_nullable=True)
+    op.alter_column(
+        'accounts',
+        'account_type',
+        existing_type=sa.String(length=20),
+        type_=account_type_enum,
+        existing_nullable=True,
+        postgresql_using="account_type::account_type",
+    )
 
-    op.alter_column('accounts', 'status',
-                    existing_type=sa.Integer(),
-                    type_=account_status_enum,
-                    server_default='ACTIVE',
-                    existing_nullable=False)
+    op.alter_column(
+        'accounts',
+        'status',
+        existing_type=sa.Integer(),
+        type_=account_status_enum,
+        server_default='ACTIVE',
+        existing_nullable=False,
+        postgresql_using=(
+            "CASE status "
+            "WHEN 1 THEN 'ACTIVE' "
+            "WHEN 0 THEN 'INACTIVE' "
+            "WHEN -1 THEN 'SUSPENDED' "
+            "END::account_status"
+        ),
+    )
 
     op.alter_column('accounts', 'balance',
                     existing_type=sa.Integer(),


### PR DESCRIPTION
## Summary
- fix casting for `account_type` and `status` columns when migrating `accounts`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687ca3fc08b48327ba7737bf90147ed1