### PR TITLE
Switch enums to IntEnum

### DIFF
--- a/app/alembic/versions/int_enum_migration.py
+++ b/app/alembic/versions/int_enum_migration.py
@@ -1,0 +1,61 @@
+"""switch to int enums"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'int_enum_migration'
+down_revision = 'bd3f600cbc1e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        'categories',
+        'type',
+        existing_type=sa.Enum('INCOME', 'PURCHASE', 'TRANSFER', name='categorytype'),
+        type_=sa.Integer(),
+        postgresql_using="CASE type WHEN 'INCOME' THEN 1 WHEN 'PURCHASE' THEN -1 ELSE NULL END",
+        existing_nullable=False,
+    )
+    op.execute('DROP TYPE IF EXISTS categorytype')
+
+    op.alter_column(
+        'accounts',
+        'account_type',
+        existing_type=sa.Enum('DEBIT_CARD', 'CREDIT_CARD', 'SAVINGS', 'INVESTMENT', 'CASH', 'OTHER', name='account_type'),
+        type_=sa.Integer(),
+        postgresql_using=(
+            "CASE account_type "
+            "WHEN 'DEBIT_CARD' THEN 1 "
+            "WHEN 'CREDIT_CARD' THEN 2 "
+            "WHEN 'SAVINGS' THEN 3 "
+            "WHEN 'INVESTMENT' THEN 4 "
+            "WHEN 'CASH' THEN 5 "
+            "WHEN 'OTHER' THEN 6 "
+            "END"
+        ),
+        existing_nullable=True,
+    )
+    op.execute('DROP TYPE IF EXISTS account_type')
+
+    op.alter_column(
+        'accounts',
+        'status',
+        existing_type=sa.Enum('ACTIVE', 'INACTIVE', 'SUSPENDED', name='account_status'),
+        type_=sa.Integer(),
+        server_default='1',
+        postgresql_using=(
+            "CASE status "
+            "WHEN 'ACTIVE' THEN 1 "
+            "WHEN 'INACTIVE' THEN 0 "
+            "WHEN 'SUSPENDED' THEN -1 "
+            "END"
+        ),
+        existing_nullable=False,
+    )
+    op.execute('DROP TYPE IF EXISTS account_status')
+
+
+def downgrade() -> None:
+    pass

--- a/app/api/v1/accounts.py
+++ b/app/api/v1/accounts.py
@@ -30,9 +30,7 @@ async def create_account(
         user_id=user.id,
         account_name=data.account_name,
         account_number=data.account_number,
-        account_type=(
-            AccountType(data.account_type) if data.account_type is not None else None
-        ),
+        account_type=data.account_type,
         balance=data.initial_balance,
         initial_balance=data.initial_balance,
     )

--- a/app/models/accounts.py
+++ b/app/models/accounts.py
@@ -1,11 +1,12 @@
 from database import Base
-from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, func, Enum as SQLEnum
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, func
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import UUID
 from uuid import uuid4
-from enum import Enum
+from enum import IntEnum
+from .types import IntEnumType
 
-class AccountType(Enum):
+class AccountType(IntEnum):
     DEBIT_CARD = 1
     CREDIT_CARD = 2
     SAVINGS = 3
@@ -13,7 +14,7 @@ class AccountType(Enum):
     CASH = 5
     OTHER = 6
 
-class AccountStatus(Enum):
+class AccountStatus(IntEnum):
     ACTIVE = 1
     INACTIVE = 0
     SUSPENDED = -1
@@ -25,8 +26,8 @@ class Account(Base):
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     account_name = Column(String(50), nullable=True)
     account_number = Column(String(20), nullable=True, unique=True)
-    account_type = Column(SQLEnum(AccountType), nullable=True)
-    status = Column(SQLEnum(AccountStatus), default=1, nullable=False)
+    account_type = Column(IntEnumType(AccountType), nullable=True)
+    status = Column(IntEnumType(AccountStatus), default=AccountStatus.ACTIVE, nullable=False)
     balance = Column(Integer, nullable=False, default=0)
     initial_balance = Column(Integer, nullable=False, default=0)
     limit = Column(Integer, nullable=True)  # лимит для кредитных карт

--- a/app/models/categories.py
+++ b/app/models/categories.py
@@ -1,10 +1,11 @@
 from database import Base
-from sqlalchemy import Column, String, Enum as SQLEnum, ForeignKey, DateTime, func
+from sqlalchemy import Column, String, ForeignKey, DateTime, func
 from sqlalchemy.dialects.postgresql import UUID
 from uuid import uuid4
-from enum import Enum
+from enum import IntEnum
+from .types import IntEnumType
 
-class CategoryType(Enum):
+class CategoryType(IntEnum):
     INCOME = 1
     PURCHASE = -1
 
@@ -37,7 +38,7 @@ class Category(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
     name = Column(String(50), nullable=False)
-    type = Column(SQLEnum(CategoryType), nullable=False)
+    type = Column(IntEnumType(CategoryType), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 

--- a/app/models/types.py
+++ b/app/models/types.py
@@ -1,0 +1,21 @@
+from sqlalchemy.types import TypeDecorator, Integer
+
+class IntEnumType(TypeDecorator):
+    """Store IntEnum values as integers in the database."""
+
+    impl = Integer
+    cache_ok = True
+
+    def __init__(self, enum_cls, *args, **kwargs):
+        self.enum_cls = enum_cls
+        super().__init__(*args, **kwargs)
+
+    def process_bind_param(self, value, dialect):
+        if value is None:
+            return None
+        return int(value)
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return None
+        return self.enum_cls(value)

--- a/app/models/users.py
+++ b/app/models/users.py
@@ -3,9 +3,10 @@ from sqlalchemy import Column, Integer, String, DateTime, func, Boolean, LargeBi
 from sqlalchemy.orm import relationship
 from uuid import uuid4
 from sqlalchemy.dialects.postgresql import UUID
-from enum import Enum
+from enum import IntEnum
+from .types import IntEnumType
 
-class Status(Enum):
+class Status(IntEnum):
     ACTIVE = 1
     INACTIVE = 0
     SUSPENDED = -1
@@ -22,7 +23,7 @@ class User(Base):
     profile_image = Column(String(255), nullable=True)
     totp_secret = Column(LargeBinary, nullable=True)
     is_totp_enabled = Column(Boolean, default=False, nullable=False)
-    status = Column(Integer, default=1, nullable=False)
+    status = Column(IntEnumType(Status), default=Status.ACTIVE, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 

--- a/app/schemas/account.py
+++ b/app/schemas/account.py
@@ -1,18 +1,19 @@
 import uuid
 from datetime import datetime
 from pydantic import BaseModel
+from models.accounts import AccountType
 
 class AccountCreate(BaseModel):
     account_name: str | None = None
     account_number: str | None = None
-    account_type: int | None = None
+    account_type: AccountType | None = None
     initial_balance: int = 0
 
 class AccountRead(BaseModel):
     id: uuid.UUID
     account_name: str | None = None
     account_number: str | None = None
-    account_type: int | None = None
+    account_type: AccountType | None = None
     balance: int
     created_at: datetime
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime
 from pydantic import BaseModel, EmailStr
+from models.users import Status
 
 class UserBase(BaseModel):
     username: str
@@ -15,7 +16,7 @@ class UserRead(UserBase):
     id: uuid.UUID
     email: EmailStr
     profile_image: str | None = None
-    status: int
+    status: Status
     created_at: datetime
     updated_at: datetime
 

--- a/mobile_frontend/lib/core/helpers/enums_helpers.dart
+++ b/mobile_frontend/lib/core/helpers/enums_helpers.dart
@@ -42,4 +42,13 @@ extension CategoryTypeX on CategoryType {
         return CategoryType.income;
     }
   }
+
+  int get value {
+    switch (this) {
+      case CategoryType.income:
+        return 1;
+      case CategoryType.purchase:
+        return -1;
+    }
+  }
 }

--- a/mobile_frontend/lib/features/budget/data/model/create_category_request.dart
+++ b/mobile_frontend/lib/features/budget/data/model/create_category_request.dart
@@ -8,6 +8,6 @@ class CreateCategoryRequest {
 
   Map<String, dynamic> toJson() => {
         'name': name,
-        'type': type.name,
+        'type': type.value,
       };
 }


### PR DESCRIPTION
## Summary
- add `IntEnumType` for storing enums as integers
- switch account, category and user models to `IntEnum`
- update Pydantic schemas and API for new enum types
- add migration to convert DB columns to integers
- adjust Flutter code to send numeric enum values

## Testing
- `python -m compileall app`

------
https://chatgpt.com/codex/tasks/task_e_687caeafba888327aee9c48802129155