### PR TITLE
Show accounts when adding transfer

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/cubit/transaction_cubit.dart
+++ b/mobile_frontend/lib/features/budget/presentation/cubit/transaction_cubit.dart
@@ -105,7 +105,11 @@ class TransactionCubit extends Cubit<TransactionState> {
     final result = await _getAccounts(const NoParams());
     result.fold(
       (failure) => emit(state.copyWith(errorMessage: failure.errorMessage)),
-      (data) => emit(state.copyWith(accounts: data)),
+      (data) {
+        final initialAccount =
+            state.accountId.isEmpty && data.isNotEmpty ? data.first.id : state.accountId;
+        emit(state.copyWith(accounts: data, accountId: initialAccount));
+      },
     );
   }
 

--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -151,14 +151,14 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                               crossAxisSpacing: AppSizes.spaceXS8.w,
                               mainAxisSpacing: AppSizes.spaceXS8.w,
                               children: [
-                                ...state.type == TransactionType.transfer
+                                ...(state.type == TransactionType.transfer
                                     ? state.accounts
                                         .where((a) => a.id != state.accountId)
                                         .map((e) => _accountItem(context, cubit, e))
                                         .toList()
                                     : state.categories
                                         .map((e) => _categoryItem(context, cubit, e))
-                                        .toList(),
+                                        .toList()),
                                 if (state.type != TransactionType.transfer)
                                   _addCategoryButton(context, cubit),
                               ],


### PR DESCRIPTION
## Summary
- automatically select the first account when loading accounts
- fix account/category grid rendering logic

## Testing
- `flutter` and `dart` unavailable, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_687cc50406708327a71665692d9c90f6