### PR TITLE
Fix transfer transaction category lookup

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/cubit/transaction_cubit.dart
+++ b/mobile_frontend/lib/features/budget/presentation/cubit/transaction_cubit.dart
@@ -94,6 +94,10 @@ class TransactionCubit extends Cubit<TransactionState> {
   void setNote(String note) => emit(state.copyWith(note: note));
 
   Future<void> loadCategories() async {
+    if (state.type == TransactionType.transfer) {
+      emit(state.copyWith(categories: []));
+      return;
+    }
     final result = await _getCategories(GetCategoriesParams(state.type.name));
     result.fold(
       (failure) => emit(state.copyWith(errorMessage: failure.errorMessage)),


### PR DESCRIPTION
## Summary
- skip API call for categories when transaction type is transfer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f5db7d928832781ce6370055e7a26