### PR TITLE
Add scrollable calendar date picker

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -115,15 +115,7 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                                 ),
                                 SizedBox(height: AppSizes.spaceM16.h),
                                 GestureDetector(
-                                  onTap: () async {
-                                    final picked = await showDatePicker(
-                                      context: context,
-                                      initialDate: state.date,
-                                      firstDate: DateTime(2000),
-                                      lastDate: DateTime(2100),
-                                    );
-                                    if (picked != null) cubit.setDate(picked);
-                                  },
+                                  onTap: () => _showCalendarPicker(context, cubit),
                                   child: Row(
                                     children: [
                                       const Icon(Icons.calendar_today, size: 20),
@@ -319,6 +311,42 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
         alignment: Alignment.center,
         child: const Icon(Icons.add),
       ),
+    );
+  }
+  Future<void> _showCalendarPicker(BuildContext context, TransactionCubit cubit) async {
+    DateTime tempDate = cubit.state.date;
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(AppSizes.borderSM16)),
+      ),
+      builder: (_) {
+        return StatefulBuilder(
+          builder: (context, setState) => Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CalendarDatePicker(
+                initialDate: tempDate,
+                firstDate: DateTime(2000),
+                lastDate: DateTime(2100),
+                onDateChanged: (d) => setState(() => tempDate = d),
+              ),
+              Padding(
+                padding: EdgeInsets.all(AppSizes.paddingM.h),
+                child: WButton(
+                  onTap: () {
+                    cubit.setDate(tempDate);
+                    Navigator.of(context).pop();
+                  },
+                  text: 'Select',
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- make Add Transaction date selector open a scrollable calendar

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f67551d5c8327ab9f0fe0b17e2c80