### PR TITLE
feat: add placeholder for transaction amount

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -116,6 +116,9 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                                 keyboardType: TextInputType.number,
                                 textAlign: TextAlign.right,
                                 onChanged: (v) => cubit.setAmount(double.tryParse(v) ?? 0),
+                                decoration: const InputDecoration(
+                                  hintText: 'Enter transaction sum',
+                                ),
                               ),
                               SizedBox(height: AppSizes.spaceM16.h),
                               Row(


### PR DESCRIPTION
## Summary
- show hint text when entering a transaction sum

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68970df77540832795abf7fb15ca18ba