### PR TITLE
feat: always show UZS suffix

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -111,26 +111,37 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                                   _typeButton(context, cubit, TransactionType.transfer, 'Transfer'),
                                 ],
                               ),
-                              TextField(
-                                controller: _amountController,
-                                keyboardType: TextInputType.number,
-                                textAlign: TextAlign.right,
-                                onChanged: (v) => cubit.setAmount(double.tryParse(v) ?? 0),
-                                style: const TextStyle(
-                                  color: AppColors.textPrimary,
-                                  fontSize: 40,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                                decoration: const InputDecoration(
-                                  hintText: '0',
-                                  hintStyle: TextStyle(
-                                    color: AppColors.def,
-                                    fontSize: 40,
-                                    fontWeight: FontWeight.bold,
+                              Row(
+                                mainAxisAlignment: MainAxisAlignment.end,
+                                children: [
+                                  Expanded(
+                                    child: TextField(
+                                      controller: _amountController,
+                                      keyboardType: TextInputType.number,
+                                      textAlign: TextAlign.right,
+                                      onChanged: (v) => cubit.setAmount(double.tryParse(v) ?? 0),
+                                      style: const TextStyle(
+                                        color: AppColors.textPrimary,
+                                        fontSize: 40,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                      decoration: const InputDecoration(
+                                        hintText: '0',
+                                        hintStyle: TextStyle(
+                                          color: AppColors.def,
+                                          fontSize: 40,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                        enabledBorder: UnderlineInputBorder(
+                                          borderSide: BorderSide(color: AppColors.def, width: 1),
+                                        ),
+                                        focusedBorder: UnderlineInputBorder(
+                                          borderSide: BorderSide(color: AppColors.accent, width: 2),
+                                        ),
+                                      ),
+                                    ),
                                   ),
-
-                                  // Always-visible currency with padding
-                                  suffix: Padding(
+                                  const Padding(
                                     padding: EdgeInsets.only(left: 8),
                                     child: Text(
                                       'UZS',
@@ -141,14 +152,7 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                                       ),
                                     ),
                                   ),
-
-                                  enabledBorder: UnderlineInputBorder(
-                                    borderSide: BorderSide(color: AppColors.def, width: 1),
-                                  ),
-                                  focusedBorder: UnderlineInputBorder(
-                                    borderSide: BorderSide(color: AppColors.accent, width: 2),
-                                  ),
-                                ),
+                                ],
                               ),
                               SizedBox(height: AppSizes.spaceM16.h),
                               Row(


### PR DESCRIPTION
## Summary
- ensure "UZS" suffix is always visible on transaction amount field

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689718c5588c83279f9154faf85683de