### PR TITLE
Keep account/category lists pinned in transaction modal

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -75,7 +75,8 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                   ),
                   child: Column(
                     children: [
-                      Expanded(
+                      Flexible(
+                        fit: FlexFit.loose,
                         child: SingleChildScrollView(
                           padding: EdgeInsets.symmetric(
                             vertical: AppSizes.paddingXS.w,
@@ -230,28 +231,29 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                       Expanded(
                         child: Container(
                           width: double.infinity,
+                          alignment: Alignment.topCenter,
                           padding: EdgeInsets.all(AppSizes.paddingM.h),
                           child: state.type == TransactionType.transfer
-                            ? ListView.separated(
-                              shrinkWrap: true,
-                              physics: const BouncingScrollPhysics(),
-                              itemCount: state.accounts.length,
-                              separatorBuilder: (c, i) => const Divider(),
-                              itemBuilder: (c, i) {
-                                final acc = state.accounts[i];
-                                return _accountItem(context, cubit, acc);
-                              },
-                            )
-                            : GridView.count(
-                              shrinkWrap: true,
-                              crossAxisCount: 3,
-                              crossAxisSpacing: AppSizes.space3,
-                              mainAxisSpacing: AppSizes.space3,
-                              children: [
-                                for (final cat in state.categories) _categoryItem(context, cubit, cat),
-                                _addCategoryButton(context, cubit)
-                              ],
-                            ),
+                              ? ListView.separated(
+                                  physics: const BouncingScrollPhysics(),
+                                  itemCount: state.accounts.length,
+                                  separatorBuilder: (c, i) => const Divider(),
+                                  itemBuilder: (c, i) {
+                                    final acc = state.accounts[i];
+                                    return _accountItem(context, cubit, acc);
+                                  },
+                                )
+                              : GridView.count(
+                                  crossAxisCount: 3,
+                                  crossAxisSpacing: AppSizes.space3,
+                                  mainAxisSpacing: AppSizes.space3,
+                                  physics: const BouncingScrollPhysics(),
+                                  children: [
+                                    for (final cat in state.categories)
+                                      _categoryItem(context, cubit, cat),
+                                    _addCategoryButton(context, cubit)
+                                  ],
+                                ),
                         ),
                       ),
                       Padding(


### PR DESCRIPTION
## Summary
- Ensure account/type controls use a flexible layout so the selectable lists appear at the top of the expanded sheet.
- Align account and category selections to the top of the modal so they remain visible when the sheet grows.

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68972553b0048327a1e4f3e9d590fdcf