### PR TITLE
fix: pin save button to page bottom

### DIFF
--- a/mobile_frontend/lib/features/profile/presentation/pages/edit_name_page.dart
+++ b/mobile_frontend/lib/features/profile/presentation/pages/edit_name_page.dart
@@ -50,18 +50,23 @@ class _EditNamePageState extends State<EditNamePage> {
                   controller: _lastNameController,
                   decoration: const InputDecoration(labelText: 'Last Name'),
                 ),
-                const Spacer(),
-                WButton(
-                  onTap: () {
-                    context.read<ProfileCubit>().updateName(
-                          _firstNameController.text,
-                          _lastNameController.text,
-                        );
-                    Navigator.of(context).pop();
-                  },
-                  text: 'Save',
-                ),
               ],
+            ),
+          ),
+          bottomNavigationBar: Padding(
+            padding: const EdgeInsets.all(16),
+            child: SafeArea(
+              top: false,
+              child: WButton(
+                onTap: () {
+                  context.read<ProfileCubit>().updateName(
+                        _firstNameController.text,
+                        _lastNameController.text,
+                      );
+                  Navigator.of(context).pop();
+                },
+                text: 'Save',
+              ),
             ),
           ),
         );


### PR DESCRIPTION
## Summary
- keep edit name save button fixed to bottom of the screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68972a20a10483279df9a818cfc350e7