### PR TITLE
Ensure grid and list scroll areas fill available height

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -232,33 +232,31 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                       ),
                       SizedBox(height: AppSizes.spaceM16.h),
                       Expanded(
-                        child: Container(
-                          width: double.infinity,
-                          alignment: Alignment.topCenter,
+                        child: Padding(
                           padding: EdgeInsets.all(AppSizes.paddingM.h),
                           child: state.type == TransactionType.transfer
-                            ? ListView.separated(
-                              padding: EdgeInsets.zero,
-                              physics: const BouncingScrollPhysics(),
-                              itemCount: state.accounts.length,
-                              separatorBuilder: (c, i) => const Divider(),
-                              itemBuilder: (c, i) {
-                                final acc = state.accounts[i];
-                                return _accountItem(context, cubit, acc);
-                              },
-                            )
-                            : GridView.count(
-                              padding: EdgeInsets.zero,
-                              crossAxisCount: 3,
-                              crossAxisSpacing: AppSizes.space3,
-                              mainAxisSpacing: AppSizes.space3,
-                              physics: const BouncingScrollPhysics(),
-                              children: [
-                                for (final cat in state.categories)
-                                  _categoryItem(context, cubit, cat),
-                                _addCategoryButton(context, cubit)
-                              ],
-                            ),
+                              ? ListView.separated(
+                                  padding: EdgeInsets.zero,
+                                  physics: const BouncingScrollPhysics(),
+                                  itemCount: state.accounts.length,
+                                  separatorBuilder: (c, i) => const Divider(),
+                                  itemBuilder: (c, i) {
+                                    final acc = state.accounts[i];
+                                    return _accountItem(context, cubit, acc);
+                                  },
+                                )
+                              : GridView.count(
+                                  padding: EdgeInsets.zero,
+                                  crossAxisCount: 3,
+                                  crossAxisSpacing: AppSizes.space3,
+                                  mainAxisSpacing: AppSizes.space3,
+                                  physics: const BouncingScrollPhysics(),
+                                  children: [
+                                    for (final cat in state.categories)
+                                      _categoryItem(context, cubit, cat),
+                                    _addCategoryButton(context, cubit)
+                                  ],
+                                ),
                         ),
                       ),
                     ],

--- a/mobile_frontend/lib/features/budget/presentation/pages/budget_page.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/budget_page.dart
@@ -122,44 +122,46 @@ class _BudgetPageState extends State<BudgetPage> {
             ),
           ),
           const SizedBox(height: 12),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: context.watch<BudgetCubit>().state.transactions.isEmpty
-              ? Container(
-                width: double.infinity,
-                padding: const EdgeInsets.all(20),
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(16),
-                  border: Border.all(
-                    color: const Color(0xFFCBD5E1),
-                    style: BorderStyle.solid,
-                  ),
-                ),
-                child: const Text(
-                  'No operations on this day',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(color: Colors.grey),
-                ),
-              )
-            : ListView.separated(
-              itemCount: context.watch<BudgetCubit>().state.transactions.length,
-              separatorBuilder: (_, __) => const Divider(),
-              itemBuilder: (context, index) {
-                final tx = context.watch<BudgetCubit>().state.transactions[index];
-                return ListTile(
-                  title: Text(tx.title),
-                  subtitle: Text(
-                    DateFormat('dd MMM yyyy').format(tx.date),
-                  ),
-                  trailing: Text(
-                    '${tx.isIncome ? '+' : '-'}${tx.amount.abs()} ₽',
-                    style: TextStyle(
-                      color: tx.isIncome ? Colors.green : Colors.red,
-                      fontWeight: FontWeight.bold,
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: context.watch<BudgetCubit>().state.transactions.isEmpty
+                  ? Container(
+                      width: double.infinity,
+                      padding: const EdgeInsets.all(20),
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(16),
+                        border: Border.all(
+                          color: const Color(0xFFCBD5E1),
+                          style: BorderStyle.solid,
+                        ),
+                      ),
+                      child: const Text(
+                        'No operations on this day',
+                        textAlign: TextAlign.center,
+                        style: TextStyle(color: Colors.grey),
+                      ),
+                    )
+                  : ListView.separated(
+                      itemCount: context.watch<BudgetCubit>().state.transactions.length,
+                      separatorBuilder: (_, __) => const Divider(),
+                      itemBuilder: (context, index) {
+                        final tx = context.watch<BudgetCubit>().state.transactions[index];
+                        return ListTile(
+                          title: Text(tx.title),
+                          subtitle: Text(
+                            DateFormat('dd MMM yyyy').format(tx.date),
+                          ),
+                          trailing: Text(
+                            '${tx.isIncome ? '+' : '-'}${tx.amount.abs()} ₽',
+                            style: TextStyle(
+                              color: tx.isIncome ? Colors.green : Colors.red,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        );
+                      },
                     ),
-                  ),
-                );
-              },
             ),
           ),
         ],


### PR DESCRIPTION
## Summary
- make transaction modal grid/list fill available height
- expand budget page transaction list to screen bottom

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*

------
https://chatgpt.com/codex/tasks/task_e_689736cf0cb083278438e1fc63c82df5