### PR TITLE
Fix grid view bottom spacing in add transaction page

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -233,7 +233,7 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                       SizedBox(height: AppSizes.spaceM16.h),
                       Expanded(
                         child: Padding(
-                          padding: EdgeInsets.all(AppSizes.paddingM.h),
+                          padding: EdgeInsets.symmetric(horizontal: AppSizes.paddingM.h),
                           child: state.type == TransactionType.transfer
                               ? ListView.separated(
                                   padding: EdgeInsets.zero,


### PR DESCRIPTION
## Summary
- ensure category grid extends to bottom by removing vertical padding

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68973bf7b20483279deffbcdc04fc39e