### PR TITLE
Fix add transaction grid view overlay by disabling body extension

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -58,7 +58,7 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
             top: true,
             bottom: false,
             child: Scaffold(
-              extendBody: true,
+              extendBody: false,
               resizeToAvoidBottomInset: true,
               backgroundColor: AppColors.transparent,
               body: ClipRRect(


### PR DESCRIPTION
## Summary
- prevent AddTransactionModal scaffold body from extending under the save button

## Testing
- `flutter --version` *(fails: command not found)*
- `sudo apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689740701d28832795cdd0c4f7025d1a