### PR TITLE
Ensure add transaction grid view stops above save button

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -52,16 +52,14 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
     return BlocBuilder<TransactionCubit, TransactionState>(
       builder: (context, state) {
         final cubit = context.read<TransactionCubit>();
-        return Container(
-          height: MediaQuery.of(context).size.height,
-          child: SafeArea(
-            top: true,
-            bottom: false,
-            child: Scaffold(
-              extendBody: true,
-              resizeToAvoidBottomInset: true,
-              backgroundColor: AppColors.transparent,
-              body: ClipRRect(
+        return SafeArea(
+          top: true,
+          bottom: false,
+          child: Scaffold(
+            extendBody: false,
+            resizeToAvoidBottomInset: true,
+            backgroundColor: AppColors.transparent,
+            body: ClipRRect(
                 borderRadius: const BorderRadius.only(
                   topLeft: Radius.circular(AppSizes.borderSM16),
                   topRight: Radius.circular(AppSizes.borderSM16),
@@ -285,8 +283,7 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                 ),
               ),
             ),
-          ),
-        );
+          );
       },
     );
   }


### PR DESCRIPTION
## Summary
- remove explicit screen-height container so Scaffold can reserve space for the Save button

## Testing
- `flutter --version` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689740701d28832795cdd0c4f7025d1a