### PR TITLE
Ensure categories grid fills modal

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -75,16 +75,14 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                   ),
                   child: Column(
                     children: [
-                      Flexible(
-                        fit: FlexFit.loose,
-                        child: SingleChildScrollView(
-                          padding: EdgeInsets.symmetric(
-                            vertical: AppSizes.paddingXS.w,
-                            horizontal: AppSizes.paddingM.h,
-                          ),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.center,
-                            children: [
+                      SingleChildScrollView(
+                        padding: EdgeInsets.symmetric(
+                          vertical: AppSizes.paddingXS.w,
+                          horizontal: AppSizes.paddingM.h,
+                        ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: [
                               DropdownButton<String>(
                                 hint: Text('Main', style: AppTextStyles.bodyRegular),
                                 menuMaxHeight: 100.h,


### PR DESCRIPTION
## Summary
- Ensure category selector in AddTransactionModal fills remaining space

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689756f090c8832791490397f713a637