### PR TITLE
Make save button transparent

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -280,6 +280,7 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                       text: 'Save',
                       isDisabled: !state.isValid || state.status.isLoading(),
                       isLoading: state.status.isLoading(),
+                      backgroundColor: AppColors.transparent,
                     );
                   },
                 ),


### PR DESCRIPTION
## Summary
- Add transparent background to save button so categories behind remain visible

## Testing
- `dart format lib/features/budget/presentation/pages/add_transaction_modal.dart` (fails: command not found)
- `flutter analyze` (fails: command not found)
- `flutter test` (fails: command not found)
- `apt-get install -y dart` (fails: unable to locate package)
- `apt-get install -y flutter` (fails: unable to locate package)


------
https://chatgpt.com/codex/tasks/task_e_68975e2c28c48327806ce0e1155a327e