### PR TITLE
Make bottom navigation bar transparent

### DIFF
--- a/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
+++ b/mobile_frontend/lib/features/main/presentation/pages/main_page.dart
@@ -60,6 +60,7 @@ class _MainPageState extends State<MainPage> {
       builder: (context, state) {
         return Scaffold(
           backgroundColor: AppColors.background,
+          extendBody: true,
           body: IndexedStack(
             index: state.currentIndex,
             children: [

--- a/mobile_frontend/lib/features/shared/presentation/widgets/navbar/curved_bottom_navbar.dart
+++ b/mobile_frontend/lib/features/shared/presentation/widgets/navbar/curved_bottom_navbar.dart
@@ -32,7 +32,7 @@ class CurvedBottomNavbar extends StatelessWidget {
     required this.items,
     this.selectedGradient = const [AppColors.primary, AppColors.primary],
     this.inactiveColor = AppColors.def,
-    this.backgroundColor = AppColors.textPrimary,
+    this.backgroundColor = AppColors.transparent,
     this.iconSize = AppSizes.navbarIcon,
   });
 


### PR DESCRIPTION
## Summary
- Allow Scaffold body to render behind bottom navigation bar
- Default curved navbar background to transparent for unobstructed content

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68975fc3ec0c832784fcca15c15d40ff