### PR TITLE
refactor: use abstract class for budget repository

### DIFF
--- a/mobile_frontend/lib/features/budget/data/repository/budget_repository_impl.dart
+++ b/mobile_frontend/lib/features/budget/data/repository/budget_repository_impl.dart
@@ -12,7 +12,7 @@ import '../model/account.dart';
 import '../model/category.dart';
 import '../model/create_category_request.dart';
 
-class BudgetRepositoryImpl with BudgetRepository {
+class BudgetRepositoryImpl implements BudgetRepository {
   final ApiClient _client;
   BudgetRepositoryImpl(this._client);
 

--- a/mobile_frontend/lib/features/budget/domain/repository/budget_repository.dart
+++ b/mobile_frontend/lib/features/budget/domain/repository/budget_repository.dart
@@ -7,7 +7,7 @@ import '../../data/model/account.dart';
 import '../../data/model/category.dart';
 import '../../data/model/create_category_request.dart';
 
-mixin BudgetRepository {
+abstract class BudgetRepository {
   Future<Either<Failure, List<Transaction>>> transactionsByDate(DateTime date);
   Future<Either<Failure, void>> createTransaction(CreateTransactionRequest request);
   Future<Either<Failure, void>> createAccount(CreateAccountRequest request);


### PR DESCRIPTION
## Summary
- replace BudgetRepository mixin with abstract class
- implement BudgetRepository via implements keyword

## Testing
- `dart format mobile_frontend/lib/features/budget/domain/repository/budget_repository.dart mobile_frontend/lib/features/budget/data/repository/budget_repository_impl.dart` (fails: command not found)
- `dart test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6897900a80108327b679ae4f13f61e02