### PR TITLE
Fix transfer account selection updating main account

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -343,7 +343,7 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
       icon: Icons.account_balance_wallet,
       selectedIcon: Icons.account_balance_wallet,
       selected: selected,
-      onTap: () => cubit.setAccountId(acc.id),
+      onTap: () => cubit.setToAccountId(acc.id),
       // If you use it in a vertical ListView, give it a bit more height:
       height: 90.h,
       color: AppColors.primary,


### PR DESCRIPTION
## Summary
- ensure selecting a transfer destination only updates the destination account

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68979fdc28e083279e5fb0ea8a00917b