### PR TITLE
Remove separators from account list in add transaction modal

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -232,19 +232,18 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                         child: Padding(
                           padding: EdgeInsets.symmetric(horizontal: AppSizes.paddingM.h),
                           child: state.type == TransactionType.transfer
-                            ? ListView.separated(
-                              padding: EdgeInsets.only(
-                                bottom: AppSizes.buttonHeight.h + AppSizes.paddingNavBar.h,
-                              ),
-                              physics: const BouncingScrollPhysics(),
-                              itemCount: state.accounts.length,
-                              separatorBuilder: (c, i) => const Divider(),
-                              itemBuilder: (c, i) {
-                                final acc = state.accounts[i];
-                                return _accountItem(context, cubit, acc);
-                              },
-                            )
-                            : GridView.count(
+                              ? ListView.builder(
+                                padding: EdgeInsets.only(
+                                  bottom: AppSizes.buttonHeight.h + AppSizes.paddingNavBar.h,
+                                ),
+                                physics: const BouncingScrollPhysics(),
+                                itemCount: state.accounts.length,
+                                itemBuilder: (c, i) {
+                                  final acc = state.accounts[i];
+                                  return _accountItem(context, cubit, acc);
+                                },
+                              )
+                              : GridView.count(
                               padding: EdgeInsets.only(
                                 bottom: AppSizes.buttonHeight.h + AppSizes.paddingNavBar.h,
                               ),


### PR DESCRIPTION
## Summary
- Replace `ListView.separated` with `ListView.builder` in add transaction modal to remove dividers between account items

## Testing
- `dart format lib/features/budget/presentation/pages/add_transaction_modal.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897a2d3b8f08327b0591c1c3ada8d7d