### PR TITLE
Add transparent divider to account list in add transaction modal

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -86,7 +86,10 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                           crossAxisAlignment: CrossAxisAlignment.center,
                           children: [
                             DropdownButton<String>(
-                              hint: Text('Main', style: AppTextStyles.bodyRegular),
+                              hint: Text(
+                                'Main',
+                                style: AppTextStyles.bodyRegular,
+                              ),
                               menuMaxHeight: 100.h,
                               menuWidth: double.maxFinite,
                               alignment: Alignment.center,
@@ -95,26 +98,48 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                               dropdownColor: AppColors.primary,
                               focusColor: AppColors.secondary,
                               borderRadius: const BorderRadius.only(
-                                  bottomRight: Radius.circular(AppSizes.borderSM16),
-                                  bottomLeft: Radius.circular(AppSizes.borderSM16)),
-                              value: state.accountId.isNotEmpty ? state.accountId : null,
+                                bottomRight: Radius.circular(
+                                  AppSizes.borderSM16,
+                                ),
+                                bottomLeft: Radius.circular(
+                                  AppSizes.borderSM16,
+                                ),
+                              ),
+                              value: state.accountId.isNotEmpty
+                                  ? state.accountId
+                                  : null,
                               onChanged: (val) => cubit.setAccountId(val ?? ''),
                               items: state.accounts
-                                .map(
-                                  (a) => DropdownMenuItem(
-                                    value: a.id,
-                                    child: Text(a.name ?? 'Account'),
-                                  ),
-                                )
-                                .toList(),
+                                  .map(
+                                    (a) => DropdownMenuItem(
+                                      value: a.id,
+                                      child: Text(a.name ?? 'Account'),
+                                    ),
+                                  )
+                                  .toList(),
                             ),
                             Row(
                               children: [
-                                _typeButton(context, cubit, TransactionType.income, 'Income'),
+                                _typeButton(
+                                  context,
+                                  cubit,
+                                  TransactionType.income,
+                                  'Income',
+                                ),
                                 SizedBox(width: AppSizes.spaceXXS5.w),
-                                _typeButton(context, cubit, TransactionType.purchase, 'Purchase'),
+                                _typeButton(
+                                  context,
+                                  cubit,
+                                  TransactionType.purchase,
+                                  'Purchase',
+                                ),
                                 SizedBox(width: AppSizes.spaceXXS5.w),
-                                _typeButton(context, cubit, TransactionType.transfer, 'Transfer'),
+                                _typeButton(
+                                  context,
+                                  cubit,
+                                  TransactionType.transfer,
+                                  'Transfer',
+                                ),
                               ],
                             ),
                             Container(
@@ -129,8 +154,7 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                                 ),
                               ),
                               child: Row(
-                                crossAxisAlignment:
-                                    CrossAxisAlignment.baseline,
+                                crossAxisAlignment: CrossAxisAlignment.baseline,
                                 textBaseline: TextBaseline.alphabetic,
                                 children: [
                                   Expanded(
@@ -138,8 +162,9 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                                       controller: _amountController,
                                       keyboardType: TextInputType.number,
                                       textAlign: TextAlign.right,
-                                      onChanged: (v) => cubit
-                                          .setAmount(double.tryParse(v) ?? 0),
+                                      onChanged: (v) => cubit.setAmount(
+                                        double.tryParse(v) ?? 0,
+                                      ),
                                       style: const TextStyle(
                                         color: AppColors.textPrimary,
                                         fontSize: 40,
@@ -159,7 +184,8 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                                   ),
                                   Padding(
                                     padding: EdgeInsets.only(
-                                        left: AppSizes.spaceXS8.w),
+                                      left: AppSizes.spaceXS8.w,
+                                    ),
                                     child: const Text(
                                       'UZS',
                                       style: TextStyle(
@@ -176,16 +202,21 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                             Row(
                               children: [
                                 GestureDetector(
-                                  onTap: () => _showCalendarPicker(context, cubit),
+                                  onTap: () =>
+                                      _showCalendarPicker(context, cubit),
                                   child: Row(
                                     children: [
                                       Container(
                                         decoration: BoxDecoration(
                                           color: AppColors.def,
-                                          borderRadius: BorderRadius.circular(AppSizes.borderSmall)
+                                          borderRadius: BorderRadius.circular(
+                                            AppSizes.borderSmall,
+                                          ),
                                         ),
                                         child: const Padding(
-                                          padding: EdgeInsets.all(AppSizes.paddingS),
+                                          padding: EdgeInsets.all(
+                                            AppSizes.paddingS,
+                                          ),
                                           child: Icon(
                                             Icons.calendar_today,
                                             size: 24,
@@ -194,7 +225,11 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                                         ),
                                       ),
                                       SizedBox(width: AppSizes.spaceXS8.w),
-                                      Text(DateFormat('dd MMMM yyyy').format(state.date)),
+                                      Text(
+                                        DateFormat(
+                                          'dd MMMM yyyy',
+                                        ).format(state.date),
+                                      ),
                                     ],
                                   ),
                                 ),
@@ -206,10 +241,14 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                                       Container(
                                         decoration: BoxDecoration(
                                           color: AppColors.def,
-                                          borderRadius: BorderRadius.circular(AppSizes.borderSmall),
+                                          borderRadius: BorderRadius.circular(
+                                            AppSizes.borderSmall,
+                                          ),
                                         ),
                                         child: const Padding(
-                                          padding: EdgeInsets.all(AppSizes.paddingS),
+                                          padding: EdgeInsets.all(
+                                            AppSizes.paddingS,
+                                          ),
                                           child: Icon(
                                             Icons.sticky_note_2_rounded,
                                             size: 24,
@@ -230,34 +269,42 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                       SizedBox(height: AppSizes.spaceXL24.h),
                       Expanded(
                         child: Padding(
-                          padding: EdgeInsets.symmetric(horizontal: AppSizes.paddingM.h),
+                          padding: EdgeInsets.symmetric(
+                            horizontal: AppSizes.paddingM.h,
+                          ),
                           child: state.type == TransactionType.transfer
-                            ? ListView.separated(
-                              padding: EdgeInsets.only(
-                                bottom: AppSizes.buttonHeight.h + AppSizes.paddingNavBar.h,
-                              ),
-                              physics: const BouncingScrollPhysics(),
-                              itemCount: state.accounts.length,
-                              separatorBuilder: (c, i) => const Divider(),
-                              itemBuilder: (c, i) {
-                                final acc = state.accounts[i];
-                                return _accountItem(context, cubit, acc);
-                              },
-                            )
-                            : GridView.count(
-                              padding: EdgeInsets.only(
-                                bottom: AppSizes.buttonHeight.h + AppSizes.paddingNavBar.h,
-                              ),
-                              crossAxisCount: 3,
-                              crossAxisSpacing: AppSizes.space3,
-                              mainAxisSpacing: AppSizes.space3,
-                              physics: const BouncingScrollPhysics(),
-                              children: [
-                                for (final cat in state.categories)
-                                  _categoryItem(context, cubit, cat),
-                                _addCategoryButton(context, cubit)
-                              ],
-                            ),
+                              ? ListView.separated(
+                                  padding: EdgeInsets.only(
+                                    bottom:
+                                        AppSizes.buttonHeight.h +
+                                        AppSizes.paddingNavBar.h,
+                                  ),
+                                  physics: const BouncingScrollPhysics(),
+                                  itemCount: state.accounts.length,
+                                  itemBuilder: (c, i) {
+                                    final acc = state.accounts[i];
+                                    return _accountItem(context, cubit, acc);
+                                  },
+                                  separatorBuilder: (c, i) => const Divider(
+                                    color: AppColors.transparent,
+                                  ),
+                                )
+                              : GridView.count(
+                                  padding: EdgeInsets.only(
+                                    bottom:
+                                        AppSizes.buttonHeight.h +
+                                        AppSizes.paddingNavBar.h,
+                                  ),
+                                  crossAxisCount: 3,
+                                  crossAxisSpacing: AppSizes.space3,
+                                  mainAxisSpacing: AppSizes.space3,
+                                  physics: const BouncingScrollPhysics(),
+                                  children: [
+                                    for (final cat in state.categories)
+                                      _categoryItem(context, cubit, cat),
+                                    _addCategoryButton(context, cubit),
+                                  ],
+                                ),
                         ),
                       ),
                     ],
@@ -267,21 +314,21 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
               bottomNavigationBar: SafeArea(
                 top: false,
                 child: Padding(
-                padding: EdgeInsets.only(
-                  left: AppSizes.paddingM.h,
-                  right: AppSizes.paddingM.h,
-                ),
-                child: BlocBuilder<TransactionCubit, TransactionState>(
-                  builder: (context, state) {
-                    final cubit = context.read<TransactionCubit>();
-                    return WButton(
-                      onTap: cubit.submit,
-                      text: 'Save',
-                      isDisabled: !state.isValid || state.status.isLoading(),
-                      isLoading: state.status.isLoading(),
-                    );
-                  },
-                ),
+                  padding: EdgeInsets.only(
+                    left: AppSizes.paddingM.h,
+                    right: AppSizes.paddingM.h,
+                  ),
+                  child: BlocBuilder<TransactionCubit, TransactionState>(
+                    builder: (context, state) {
+                      final cubit = context.read<TransactionCubit>();
+                      return WButton(
+                        onTap: cubit.submit,
+                        text: 'Save',
+                        isDisabled: !state.isValid || state.status.isLoading(),
+                        isLoading: state.status.isLoading(),
+                      );
+                    },
+                  ),
                 ),
               ),
             ),
@@ -291,7 +338,12 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
     );
   }
 
-  Widget _typeButton(BuildContext context, TransactionCubit cubit, TransactionType type, String label) {
+  Widget _typeButton(
+    BuildContext context,
+    TransactionCubit cubit,
+    TransactionType type,
+    String label,
+  ) {
     final selected = cubit.state.type == type;
     return Container(
       child: GestureDetector(
@@ -304,23 +356,35 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
           }
         },
         child: Container(
-          padding: const EdgeInsets.symmetric(vertical: AppSizes.paddingS, horizontal: AppSizes.paddingM),
+          padding: const EdgeInsets.symmetric(
+            vertical: AppSizes.paddingS,
+            horizontal: AppSizes.paddingM,
+          ),
           decoration: BoxDecoration(
             color: selected ? AppColors.def : AppColors.transparent,
             borderRadius: BorderRadius.circular(AppSizes.borderMedium),
             border: Border.all(
               color: selected ? AppColors.primary : AppColors.def,
-              width: 0.5
+              width: 0.5,
             ),
           ),
           alignment: Alignment.center,
-          child: Text(label, style: selected ? AppTextStyles.bodyRegular : AppTextStyles.bodyRegular),
+          child: Text(
+            label,
+            style: selected
+                ? AppTextStyles.bodyRegular
+                : AppTextStyles.bodyRegular,
+          ),
         ),
       ),
     );
   }
 
-  Widget _categoryItem(BuildContext context, TransactionCubit cubit, Category cat) {
+  Widget _categoryItem(
+    BuildContext context,
+    TransactionCubit cubit,
+    Category cat,
+  ) {
     final selected = cubit.state.categoryId == cat.id;
     return TileButton(
       title: cat.name ?? 'Category',
@@ -335,7 +399,11 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
     );
   }
 
-  Widget _accountItem(BuildContext context, TransactionCubit cubit, Account acc) {
+  Widget _accountItem(
+    BuildContext context,
+    TransactionCubit cubit,
+    Account acc,
+  ) {
     final selected = cubit.state.toAccountId == acc.id;
     return TileButton(
       title: acc.name ?? 'Account',
@@ -385,15 +453,16 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
             borderRadius: radius,
             border: Border.all(color: AppColors.primary, width: 0.5),
           ),
-          child: const Center(
-            child: Icon(Icons.add, color: AppColors.accent),
-          ),
+          child: const Center(child: Icon(Icons.add, color: AppColors.accent)),
         ),
       ),
     );
   }
 
-  Future<void> _showCalendarPicker(BuildContext context, TransactionCubit cubit) async {
+  Future<void> _showCalendarPicker(
+    BuildContext context,
+    TransactionCubit cubit,
+  ) async {
     DateTime tempDate = cubit.state.date;
     await showModalBottomSheet(
       context: context,
@@ -439,7 +508,10 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
     );
   }
 
-  Future<void> _showNoteModal(BuildContext context, TransactionCubit cubit) async {
+  Future<void> _showNoteModal(
+    BuildContext context,
+    TransactionCubit cubit,
+  ) async {
     _noteController.text = cubit.state.note;
     await showModalBottomSheet(
       context: context,


### PR DESCRIPTION
## Summary
- Use `ListView.separated` with a transparent `Divider` to remove visible separators while maintaining layout in the add transaction modal

## Testing
- `dart format lib/features/budget/presentation/pages/add_transaction_modal.dart`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897a2d3b8f08327b0591c1c3ada8d7d