### PR TITLE
feat: add custom keyboard actions

### DIFF
--- a/mobile_frontend/pubspec.lock
+++ b/mobile_frontend/pubspec.lock
@@ -789,6 +789,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.12.17"
+  math_expressions:
+    dependency: "direct main"
+    description:
+      name: math_expressions
+      sha256: "3576593617c3870d75728a751f6ec6e606706d44e363f088ac394b5a28a98064"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   material_color_utilities:
     dependency: transitive
     description:

--- a/mobile_frontend/pubspec.yaml
+++ b/mobile_frontend/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   currency_text_input_formatter: ^2.2.9
   intl: ^0.20.2
   dartz: ^0.10.1
+  math_expressions: ^2.4.0
   flutter_launcher_icons: ^0.14.3
   image_picker: ^1.0.7
 


### PR DESCRIPTION
## Summary
- add arithmetic toolbar with operation buttons and Done
- keep Save button above keyboard while typing amounts
- add math_expressions dependency

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898150811a483279666e8dce2d634b5