### PR TITLE
Fix missing content on add transaction page

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -321,11 +321,12 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
               bottomNavigationBar: Builder(
                 builder: (context) {
                   final keyboardOpen = MediaQuery.of(context).viewInsets.bottom > 0;
+                  final cubit = context.read<TransactionCubit>();
 
                   return AnimatedContainer(
                     duration: const Duration(milliseconds: 180),
                     curve: Curves.easeOut,
-                    height: keyboardOpen ? 56 : 0,   // show only when keyboard is open
+                    height: 56,
                     child: Material(
                       color: AppColors.background,
                       elevation: 8,
@@ -336,32 +337,35 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                           child: Row(
                             mainAxisSize: MainAxisSize.min,
                             children: [
-                              _opBtn('+', () => _insertText('+', context.read<TransactionCubit>())),
-                              const SizedBox(width: 8),
-                              _opBtn('−', () => _insertText('-', context.read<TransactionCubit>())),
-                              const SizedBox(width: 8),
-                              _opBtn('×', () => _insertText('*', context.read<TransactionCubit>())),
-                              const SizedBox(width: 8),
-                              _opBtn('÷', () => _insertText('/', context.read<TransactionCubit>())),
-                              const Spacer(),
-                              TextButton(
-                                onPressed: () => _amountFocusNode.unfocus(),
-                                child: const Text('Done'),
-                              ),
-                              const SizedBox(width: 8),
+                              if (keyboardOpen) ...[
+                                _opBtn('+', () => _insertText('+', cubit)),
+                                const SizedBox(width: 8),
+                                _opBtn('−', () => _insertText('-', cubit)),
+                                const SizedBox(width: 8),
+                                _opBtn('×', () => _insertText('*', cubit)),
+                                const SizedBox(width: 8),
+                                _opBtn('÷', () => _insertText('/', cubit)),
+                                const Spacer(),
+                                TextButton(
+                                  onPressed: () => _amountFocusNode.unfocus(),
+                                  child: const Text('Done'),
+                                ),
+                                const SizedBox(width: 8),
+                              ] else
+                                const Spacer(),
                               SizedBox(
                                 height: 40,
                                 child: WButton(
                                   onTap: () {
                                     final value = _evaluate(_amountController.text);
-                                    context.read<TransactionCubit>()
+                                    cubit
                                       ..setAmount(value)
                                       ..submit();
                                   },
                                   text: 'Save',
-                                  isDisabled: !context.read<TransactionCubit>().state.isValid ||
-                                      context.read<TransactionCubit>().state.status.isLoading(),
-                                  isLoading: context.read<TransactionCubit>().state.status.isLoading(),
+                                  isDisabled: !cubit.state.isValid ||
+                                      cubit.state.status.isLoading(),
+                                  isLoading: cubit.state.status.isLoading(),
                                 ),
                               ),
                             ],


### PR DESCRIPTION
## Summary
- ensure add transaction modal's bottom bar is always visible
- hide keypad operators unless the keyboard is shown

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68981a1f430c8327a6fa1d2cdd142249