### PR TITLE
fix add transaction modal layout

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -129,14 +129,15 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                   ),
                   child: Column(
                     children: [
-                      SingleChildScrollView(
-                        padding: EdgeInsets.symmetric(
-                          vertical: AppSizes.paddingXS.w,
-                          horizontal: AppSizes.paddingM.h,
-                        ),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
+                      Flexible(
+                        child: SingleChildScrollView(
+                          padding: EdgeInsets.symmetric(
+                            vertical: AppSizes.paddingXS.w,
+                            horizontal: AppSizes.paddingM.h,
+                          ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
                             DropdownButton<String>(
                               hint: Text('Main', style: AppTextStyles.bodyRegular),
                               menuMaxHeight: 100.h,
@@ -278,6 +279,7 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                             ),
                           ],
                         ),
+                      ),
                       ),
                       SizedBox(height: AppSizes.space48.h),
                       Expanded(


### PR DESCRIPTION
## Summary
- ensure AddTransactionModal scroll content uses Flexible to avoid overflowing bottom sheet and render page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68981dc395808327a7fbc2e49049a01f