### PR TITLE
refactor: extract bottom datepicker widget

### DIFF
--- a/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart
@@ -5,11 +5,10 @@ import 'package:Finance/features/budget/presentation/widgets/add_category_item.d
 import 'package:Finance/features/budget/presentation/widgets/category_item.dart';
 import 'package:Finance/features/budget/presentation/widgets/transaction_type_button.dart';
 import 'package:Finance/features/budget/presentation/widgets/transfer_account_item.dart';
+import 'package:Finance/features/budget/presentation/widgets/bottom_datepicker_modal.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:intl/intl.dart';
 import 'package:math_expressions/math_expressions.dart';
 
 import '../../../shared/presentation/widgets/app_buttons/w_tile_button.dart';
@@ -245,37 +244,10 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
                             SizedBox(height: AppSizes.spaceM16.h),
                             Row(
                               children: [
-                                GestureDetector(
-                                  onTap:
-                                      () => _showCalendarPicker(context, cubit),
-                                  child: Row(
-                                    children: [
-                                      Container(
-                                        decoration: BoxDecoration(
-                                          color: AppColors.def.withOpacity(0.2),
-                                          borderRadius: BorderRadius.circular(
-                                            AppSizes.borderSmall,
-                                          ),
-                                        ),
-                                        child: const Padding(
-                                          padding: EdgeInsets.all(
-                                            AppSizes.paddingS,
-                                          ),
-                                          child: Icon(
-                                            Icons.calendar_today,
-                                            size: 24,
-                                            color: AppColors.textSecondary,
-                                          ),
-                                        ),
-                                      ),
-                                      SizedBox(width: AppSizes.spaceXS8.w),
-                                      Text(
-                                        DateFormat(
-                                          'dd MMMM yyyy',
-                                        ).format(state.date),
-                                      ),
-                                    ],
-                                  ),
+                                BottomDatepickerField(
+                                  date: state.date,
+                                  onSelect: cubit.setDate,
+                                  maximumDate: DateTime.now(),
                                 ),
                                 SizedBox(width: AppSizes.spaceXL24.w),
                                 GestureDetector(
@@ -550,63 +522,6 @@ class _AddTransactionModalState extends State<AddTransactionModal> {
   //     ),
   //   );
   // }
-
-  Future<void> _showCalendarPicker(
-    BuildContext context,
-    TransactionCubit cubit,
-  ) async {
-    DateTime tempDate = cubit.state.date;
-    await showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      useSafeArea: true,
-      builder: (_) {
-        return ClipRRect(
-          borderRadius: const BorderRadius.only(
-            topLeft: Radius.circular(AppSizes.borderSM16),
-            topRight: Radius.circular(AppSizes.borderSM16),
-          ),
-          child: StatefulBuilder(
-            builder:
-                (context, setState) => Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Container(
-                      height: 200.h,
-                      color: AppColors.background,
-                      child: CupertinoDatePicker(
-                        initialDateTime: tempDate,
-                        mode: CupertinoDatePickerMode.date,
-                        backgroundColor: AppColors.background,
-                        onDateTimeChanged: (d) => setState(() => tempDate = d),
-                      ),
-                    ),
-                    Container(
-                      color: AppColors.background,
-                      child: SafeArea(
-                        top: false,
-                        child: Padding(
-                          padding: EdgeInsets.only(
-                            left: AppSizes.paddingM.w,
-                            right: AppSizes.paddingM.w,
-                          ),
-                          child: WButton(
-                            onTap: () {
-                              cubit.setDate(tempDate);
-                              Navigator.of(context).pop();
-                            },
-                            text: 'Select',
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-          ),
-        );
-      },
-    );
-  }
 
   Future<void> _showNoteModal(
     BuildContext context,

--- a/mobile_frontend/lib/features/budget/presentation/widgets/bottom_datepicker_modal.dart
+++ b/mobile_frontend/lib/features/budget/presentation/widgets/bottom_datepicker_modal.dart
@@ -1,10 +1,145 @@
+import 'package:Finance/core/constants/app_colors.dart';
+import 'package:Finance/core/constants/app_sizes.dart';
+import 'package:Finance/features/shared/presentation/widgets/app_buttons/w_button.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:intl/intl.dart';
 
 class BottomDatepickerModal extends StatelessWidget {
-  const BottomDatepickerModal({super.key});
+  const BottomDatepickerModal({
+    super.key,
+    required this.initialDate,
+    required this.onSelect,
+    this.minimumDate,
+    this.maximumDate,
+  });
+
+  final DateTime initialDate;
+  final ValueChanged<DateTime> onSelect;
+  final DateTime? minimumDate;
+  final DateTime? maximumDate;
+
+  static Future<void> show(
+    BuildContext context, {
+    required DateTime initialDate,
+    required ValueChanged<DateTime> onSelect,
+    DateTime? minimumDate,
+    DateTime? maximumDate,
+  }) {
+    return showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => BottomDatepickerModal(
+        initialDate: initialDate,
+        onSelect: onSelect,
+        minimumDate: minimumDate,
+        maximumDate: maximumDate,
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    DateTime tempDate = initialDate;
+
+    return ClipRRect(
+      borderRadius: const BorderRadius.only(
+        topLeft: Radius.circular(AppSizes.borderSM16),
+        topRight: Radius.circular(AppSizes.borderSM16),
+      ),
+      child: StatefulBuilder(
+        builder: (context, setState) => Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              height: 200.h,
+              color: AppColors.background,
+              child: CupertinoDatePicker(
+                initialDateTime: tempDate,
+                minimumDate: minimumDate,
+                maximumDate: maximumDate,
+                mode: CupertinoDatePickerMode.date,
+                backgroundColor: AppColors.background,
+                onDateTimeChanged: (d) => setState(() => tempDate = d),
+              ),
+            ),
+            Container(
+              color: AppColors.background,
+              child: SafeArea(
+                top: false,
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    left: AppSizes.paddingM.w,
+                    right: AppSizes.paddingM.w,
+                  ),
+                  child: WButton(
+                    onTap: () {
+                      onSelect(tempDate);
+                      Navigator.of(context).pop();
+                    },
+                    text: 'Select',
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
+
+class BottomDatepickerField extends StatelessWidget {
+  const BottomDatepickerField({
+    super.key,
+    required this.date,
+    required this.onSelect,
+    this.minimumDate,
+    this.maximumDate,
+    this.dateFormat = 'dd MMMM yyyy',
+  });
+
+  final DateTime date;
+  final ValueChanged<DateTime> onSelect;
+  final DateTime? minimumDate;
+  final DateTime? maximumDate;
+  final String dateFormat;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => BottomDatepickerModal.show(
+        context,
+        initialDate: date,
+        onSelect: onSelect,
+        minimumDate: minimumDate,
+        maximumDate: maximumDate,
+      ),
+      child: Row(
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              color: AppColors.def.withOpacity(0.2),
+              borderRadius: BorderRadius.circular(AppSizes.borderSmall),
+            ),
+            child: const Padding(
+              padding: EdgeInsets.all(AppSizes.paddingS),
+              child: Icon(
+                Icons.calendar_today,
+                size: 24,
+                color: AppColors.textSecondary,
+              ),
+            ),
+          ),
+          SizedBox(width: AppSizes.spaceXS8.w),
+          Text(
+            DateFormat(dateFormat).format(date),
+          ),
+        ],
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add reusable `BottomDatepickerModal` with static show method and field widget
- replace inline date picker in `AddTransactionModal` with new `BottomDatepickerField`
- add optional min/max date constraints and custom format support
- limit transaction date picker to dates up to today

## Testing
- `flutter format mobile_frontend/lib/features/budget/presentation/widgets/bottom_datepicker_modal.dart mobile_frontend/lib/features/budget/presentation/pages/add_transaction_modal.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a22031c63883278079e9b6a6ed88b4